### PR TITLE
Collection Name as input option for harmonize flows

### DIFF
--- a/quick-start/src/main/java/com/marklogic/quickstart/service/FlowManagerService.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/service/FlowManagerService.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
 
 @Service
 public class FlowManagerService {
@@ -102,13 +103,20 @@ public class FlowManagerService {
         return flowManager.getFlow(entityName, flowName, flowType);
     }
 
-    public JobTicket runFlow(Flow flow, int batchSize, int threadCount, FlowStatusListener statusListener) {
+    //public JobTicket runFlow(Flow flow, int batchSize, int threadCount, FlowStatusListener statusListener) {
+      public JobTicket runFlow(Flow flow, int batchSize, int threadCount, String collectionName, FlowStatusListener statusListener) {
 
         FlowManager flowManager = getFlowManager();
+        
+        //Create Options HashMap
+        HashMap<String, Object> opts = new HashMap<String,Object>();
+        opts.put("collectionName",collectionName);
+
         FlowRunner flowRunner = flowManager.newFlowRunner()
             .withFlow(flow)
             .withBatchSize(batchSize)
             .withThreadCount(threadCount)
+	    .withOptions(opts)
             .onStatusChanged(statusListener);
         return flowRunner.run();
     }

--- a/quick-start/src/main/java/com/marklogic/quickstart/service/MlcpRunner.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/service/MlcpRunner.java
@@ -29,6 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -93,6 +95,20 @@ class MlcpRunner extends Thread {
                 .setCounts(successfulEvents.get(), failedEvents.get(), 0, 0)
                 .withEndTime(new Date());
             jobManager.saveJob(job);
+
+	    //Create MLCP .done file
+            try
+            {
+                String sDoneFilename = mlcpOptions.get("output_collections").asText();
+                sDoneFilename = sDoneFilename.substring(sDoneFilename.lastIndexOf(',') + 1).replaceAll("\"","");
+                if(!sDoneFilename.equals(""))
+                {
+                    sDoneFilename = mlcpOptions.get("input_file_path").asText() + File.separator + sDoneFilename + ".done";
+                    Files.write(Paths.get(sDoneFilename),(""+System.currentTimeMillis()).getBytes());
+                }
+            }
+            catch(Exception e){logger.debug(e.getMessage());}
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/quick-start/src/main/java/com/marklogic/quickstart/web/EntitiesController.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/web/EntitiesController.java
@@ -103,6 +103,9 @@ class EntitiesController extends EnvironmentAware {
 
         int batchSize = json.get("batchSize").asInt();
         int threadCount = json.get("threadCount").asInt();
+	
+	//Get Collection Name from request body
+	String collectionName = (json.get("collectionName")==null)?"":json.get("collectionName").asText();
 
         ResponseEntity<?> resp;
 
@@ -111,7 +114,9 @@ class EntitiesController extends EnvironmentAware {
             resp = new ResponseEntity<>(HttpStatus.CONFLICT);
         }
         else {
-            flowManagerService.runFlow(flow, batchSize, threadCount, (jobId, percentComplete, message) -> {
+            // Pass collectionName to harmonize flow
+	    // flowManagerService.runFlow(flow, batchSize, threadCount, (jobId, percentComplete, message) -> {
+	       flowManagerService.runFlow(flow, batchSize, threadCount, collectionName, (jobId, percentComplete, message) -> {
                 template.convertAndSend("/topic/flow-status", new JobStatusMessage(jobId, percentComplete, message, FlowType.HARMONIZE.toString()));
             });
             resp = new ResponseEntity<>(HttpStatus.OK);

--- a/quick-start/src/main/ui/app/entities/entities.component.ts
+++ b/quick-start/src/main/ui/app/entities/entities.component.ts
@@ -337,7 +337,9 @@ export class EntitiesComponent implements OnInit, OnDestroy {
   }
 
   runHarmonizeFlow(flow: Flow, options: any): void {
-    this.entitiesService.runHarmonizeFlow(flow, options.batchSize, options.threadCount);
+    //Pass collectionName
+    //this.entitiesService.runHarmonizeFlow(flow, options.batchSize, options.threadCount);
+    this.entitiesService.runHarmonizeFlow(flow, options.batchSize, options.threadCount, options.collectionName);
     this.snackbar.showSnackbar({
       message: flow.entityName + ': ' + flow.flowName + ' starting...',
     });

--- a/quick-start/src/main/ui/app/entities/entities.service.ts
+++ b/quick-start/src/main/ui/app/entities/entities.service.ts
@@ -69,9 +69,13 @@ export class EntitiesService {
     return this.http.post(url, mlcpOptions).subscribe(() => {});
   }
 
-  runHarmonizeFlow(flow: Flow, batchSize: number, threadCount: number) {
+  //Add collectionName to input params
+  //runHarmonizeFlow(flow: Flow, batchSize: number, threadCount: number) {
+  runHarmonizeFlow(flow: Flow, batchSize: number, threadCount: number, collectionName: string) {
     const url = this.url(`/entities/${flow.entityName}/flows/harmonize/${flow.flowName}/run`);
-    return this.http.post(url, { batchSize: batchSize, threadCount: threadCount }).subscribe(() => {});
+    //Pass collectionName
+    //return this.http.post(url, { batchSize: batchSize, threadCount: threadCount }).subscribe(() => {});
+    return this.http.post(url, { batchSize: batchSize, threadCount: threadCount, collectionName: collectionName }).subscribe(() => {});
   }
 
   public extractData = (res: Response) => {

--- a/quick-start/src/main/ui/app/harmonize-flow-options/harmonize-flow-options.component.html
+++ b/quick-start/src/main/ui/app/harmonize-flow-options/harmonize-flow-options.component.html
@@ -18,6 +18,14 @@
           name="threadCount"
           [(ngModel)]="settings.threadCount"></mdl-textfield>
       </div>
+      <!-- Collection Name Option -->
+      <div class="setting">
+        <mdl-textfield floating-label type="text"
+          label="Collection Name"
+          name="collectionName"
+          [(ngModel)]="settings.collectionName"></mdl-textfield>
+      </div>
+      <!-- Collection Name Option -->
     </div>
     <div class="mdl-dialog__actions">
       <mdl-button mdl-button-type="raised" mdl-colored="primary" mdl-ripple (click)="runHarmonize()">Run Harmonize</mdl-button>

--- a/quick-start/src/main/ui/app/harmonize-flow-options/harmonize-flow-options.component.ts
+++ b/quick-start/src/main/ui/app/harmonize-flow-options/harmonize-flow-options.component.ts
@@ -23,7 +23,8 @@ export class HarmonizeFlowOptionsComponent implements OnInit {
 
   settings: any = {
     batchSize: 100,
-    threadCount: 4
+    threadCount: 4,
+    collectionName: ''
   };
 
   constructor() {}


### PR DESCRIPTION
Please review. The features implemented in this commit are as below.

1) Modified the Harmonize Flow Input UI to accept an additional parameter(collectionName) to be passed to backend harmonize flow.

2) Modified the MLCPRunner.java to write a .done file in the input_file_path location when it has successfully completed the input flow. This helps in subscribing to the input flow complete event for a client application to trigger harmonize flow upon the completion of the input flow. Helps in tying the triggering of input flow and harmonize flow together.
