### PR TITLE
#426 resolving issue #426, correcting quick-start compilation

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/mlcp-flow-transform.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/mlcp-flow-transform.xqy
@@ -40,7 +40,10 @@ declare function mlcpFlow:transform(
         else
           fn:error(xs:QName("MISSING_FLOW"), "The specified flow " || map:get($params, "flow") || " is missing.")
 
-      let $_ := trace:set-job-id(map:get($params, "jobId"))
+      let $param-job-id := map:get($params, "jobId")
+      let $the-job-id := if ($param-job-id) then $param-job-id else sem:uuid-string()
+
+      let $_ := trace:set-job-id($the-job-id)
       let $envelope := flow:run-plugins($flow, $uri, map:get($content, "value"), $params)
       let $_ := map:put($content, "value", $envelope)
       let $_ :=

--- a/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.ts
+++ b/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.ts
@@ -474,7 +474,7 @@ export class MlcpUiComponent implements OnChanges {
 
     _.each(this.groups, (group) => {
       if (this.isGroupVisible(group.category)) {
-        _.each(group.settings, (setting) => {
+        _.each(group.settings, (setting: any) => {
           if (setting.value) {
             const key = setting.field;
             let value = setting.value;


### PR DESCRIPTION
resolving issue #426 by setting jobId to UUID value, if jobId is not provided as a parameter during mlcp ingest. 
Correcting TypeScript compilation error in quick-start,