### PR TITLE
adds performance sample

### DIFF
--- a/examples/performance-sample/README.md
+++ b/examples/performance-sample/README.md
@@ -1,0 +1,109 @@
+## data-hub performance sample
+
+This example automates the entire setup and scaffolding of a data-hub,
+complete with:
+
+- entity creation
+- input flow creation
+- sample-data retrieval
+- data ingestion
+- harmonization flow creation
+- harmonization
+
+Using the geonames cities5000 (top world cities by population) as our data
+source, we create `input-json` and `input-xml` entities, with input flows for
+each, and ingest the sample data using MLCP and our input flows, creating JSON
+and XML instances of every city. We then create four harmonization flows
+representing the cartesian product of data formats (XML, JSON) and code
+formats (XQY, SJS), and run each one.
+
+This lets us easily analyze and compare the performance of the default,
+scaffolded harmonization flows across data types. This example can also serve
+as a reference for data-hub build automation.
+
+### getting started
+
+To get started, copy `build.gradle` into an empty directory and setup a new
+data-hub:
+
+```
+gradle hubInit
+```
+
+In `gradle.properties`, set `mlUsername` and `mlPassword` to your MarkLogic admin account, and check that the other settings are appropriate for your
+environment.
+
+You can alternatively set environment-specific properties in
+`gradle-$ENV.properties`, and invoke `gradle` with `-PenvironmentName=$ENV`.
+
+### scaffold, ingest, and harmonize
+
+There's an uber-task to handle creating entities and input flows, retrieving
+and ingesting data, and creating and running the harmonization flows:
+
+```
+gradle doAll
+```
+
+Alternately, you can run these steps separately:
+
+```
+gradle mlDeploy
+gradle createEntityInput
+gradle loadInputData
+gradle allHarmonizeFlows
+```
+
+### profile
+
+There are two profiling mechanisms available in this project. The first is the
+built-in gradle profiler:
+
+```
+gradle --profile doAll
+```
+
+This will write an HTML profile report to 
+`./build/reports/profile/profile-$DATETIME.html`.
+
+There's also a custom profiling class that prints per-task execution time to
+the terminal:
+
+```
+gradle -Pprofile doAll
+```
+
+Example output:
+
+```
+BUILD SUCCESSFUL in 6m 8s
+21 actionable tasks: 21 executed
+Task timings:
+     2.742s  :hubPreInstallCheck
+     0.001s  :mlDeleteModuleTimestampsFile
+     0.004s  :mlPrepareRestApiDependencies
+    88.791s  :mlDeployApp
+     0.000s  :mlPostDeploy
+     0.000s  :mlDeploy
+     0.004s  :createJsonEntity
+     0.002s  :createInputJsonFlow
+     0.001s  :createXmlEntity
+     0.002s  :createInputXmlFlow
+     0.000s  :createEntityInput
+     0.005s  :createHarmonizeJsonSjs
+     0.003s  :createHarmonizeJsonXqy
+     0.002s  :createHarmonizeXmlSjs
+     0.002s  :createHarmonizeXmlXqy
+     0.000s  :createHarmonizeFlows
+     0.418s  :getInputData
+     3.595s  :mlLoadModules
+    52.553s  :loadJson
+    52.685s  :loadXml
+     0.003s  :loadInputData
+    51.452s  :runHarmonizeJsonSjs
+    29.802s  :runHarmonizeJsonXqy
+    55.021s  :runHarmonizeXmlSjs
+    30.660s  :runHarmonizeXmlXqy
+     0.000s  :allHarmonizeFlows
+     0.000s  :doAll
+```

--- a/examples/performance-sample/build.gradle
+++ b/examples/performance-sample/build.gradle
@@ -35,6 +35,8 @@ task createJsonEntity(type: com.marklogic.gradle.task.CreateEntityTask) {
 }
 
 task createInputXmlFlow(type: com.marklogic.gradle.task.CreateInputFlowTask) {
+  mustRunAfter createXmlEntity
+
   doFirst {
     project.ext.entityName = "input-xml"
     project.ext.flowName = "raw-input-xml"
@@ -43,6 +45,8 @@ task createInputXmlFlow(type: com.marklogic.gradle.task.CreateInputFlowTask) {
 }
 
 task createInputJsonFlow(type: com.marklogic.gradle.task.CreateInputFlowTask) {
+  mustRunAfter createJsonEntity
+
   doFirst {
     project.ext.entityName = "input-json"
     project.ext.flowName = "raw-input-json"
@@ -51,10 +55,13 @@ task createInputJsonFlow(type: com.marklogic.gradle.task.CreateInputFlowTask) {
 }
 
 task createEntityInput() {
+  mustRunAfter mlDeploy
+
   dependsOn createXmlEntity
   dependsOn createJsonEntity
   dependsOn createInputXmlFlow
   dependsOn createInputJsonFlow
+
   finalizedBy mlLoadModules
   doLast { println "created XML and JSON entities and input flows" }
 }
@@ -109,6 +116,10 @@ task prepareMlcpLog() {
 }
 
 task loadJson(type: com.marklogic.gradle.task.MlcpTask) {
+  mustRunAfter createInputXmlFlow
+  mustRunAfter mlLoadModules
+  mustRunAfter getInputData
+
   classpath = configurations.mlcp
   command = "IMPORT"
   database = mlStagingDbName
@@ -126,6 +137,10 @@ task loadJson(type: com.marklogic.gradle.task.MlcpTask) {
 }
 
 task loadXml(type: com.marklogic.gradle.task.MlcpTask) {
+  mustRunAfter createInputJsonFlow
+  mustRunAfter mlLoadModules
+  mustRunAfter getInputData
+
   classpath = configurations.mlcp
   command = "IMPORT"
   database = mlStagingDbName
@@ -143,8 +158,106 @@ task loadXml(type: com.marklogic.gradle.task.MlcpTask) {
 }
 
 task loadInputData {
-  mustRunAfter createEntityInput
   dependsOn getInputData
   dependsOn loadJson
   dependsOn loadXml
+}
+
+task createHarmonizeXmlXqy(type: com.marklogic.gradle.task.CreateHarmonizeFlowTask) {
+  mustRunAfter createEntityInput
+
+  doFirst {
+    project.ext.entityName = "input-xml"
+    project.ext.flowName = "harmonize-xml-xqy"
+    project.ext.pluginFormat = "xqy"
+    project.ext.dataFormat = "xml"
+  }
+}
+
+task createHarmonizeXmlSjs(type: com.marklogic.gradle.task.CreateHarmonizeFlowTask) {
+  mustRunAfter createEntityInput
+
+  doFirst {
+    project.ext.entityName = "input-xml"
+    project.ext.flowName = "harmonize-xml-sjs"
+    project.ext.pluginFormat = "sjs"
+    project.ext.dataFormat = "xml"
+  }
+}
+
+task createHarmonizeJsonXqy(type: com.marklogic.gradle.task.CreateHarmonizeFlowTask) {
+  mustRunAfter createEntityInput
+
+  doFirst {
+    project.ext.entityName = "input-json"
+    project.ext.flowName = "harmonize-json-xqy"
+    project.ext.pluginFormat = "xqy"
+    project.ext.dataFormat = "json"
+  }
+}
+
+task createHarmonizeJsonSjs(type: com.marklogic.gradle.task.CreateHarmonizeFlowTask) {
+  mustRunAfter createEntityInput
+
+  doFirst {
+    project.ext.entityName = "input-json"
+    project.ext.flowName = "harmonize-json-sjs"
+    project.ext.pluginFormat = "sjs"
+    project.ext.dataFormat = "json"
+  }
+}
+
+task createHarmonizeFlows() {
+  dependsOn createHarmonizeXmlXqy
+  dependsOn createHarmonizeXmlSjs
+  dependsOn createHarmonizeJsonXqy
+  dependsOn createHarmonizeJsonSjs
+  finalizedBy mlLoadModules
+}
+
+task runHarmonizeXmlXqy(type: com.marklogic.gradle.task.RunFlowTask) {
+  mustRunAfter loadInputData
+  mustRunAfter createHarmonizeXmlXqy
+
+  entityName = "input-xml"
+  flowName = "harmonize-xml-xqy"
+}
+
+task runHarmonizeXmlSjs(type: com.marklogic.gradle.task.RunFlowTask) {
+  mustRunAfter loadInputData
+  mustRunAfter createHarmonizeXmlSjs
+
+  entityName = "input-xml"
+  flowName = "harmonize-xml-sjs"
+}
+
+task runHarmonizeJsonXqy(type: com.marklogic.gradle.task.RunFlowTask) {
+  mustRunAfter loadInputData
+  mustRunAfter createHarmonizeJsonXqy
+
+  entityName = "input-json"
+  flowName = "harmonize-json-xqy"
+}
+
+task runHarmonizeJsonSjs(type: com.marklogic.gradle.task.RunFlowTask) {
+  mustRunAfter loadInputData
+  mustRunAfter createHarmonizeJsonSjs
+
+  entityName = "input-json"
+  flowName = "harmonize-json-sjs"
+}
+
+task allHarmonizeFlows() {
+  dependsOn createHarmonizeFlows
+  dependsOn runHarmonizeXmlXqy
+  dependsOn runHarmonizeXmlSjs
+  dependsOn runHarmonizeJsonXqy
+  dependsOn runHarmonizeJsonSjs
+}
+
+task doAll() {
+  dependsOn mlDeploy
+  dependsOn createEntityInput
+  dependsOn loadInputData
+  dependsOn allHarmonizeFlows
 }

--- a/examples/performance-sample/build.gradle
+++ b/examples/performance-sample/build.gradle
@@ -1,13 +1,29 @@
 plugins {
-    // this plugin lets you create properties files
-    // for multiple environments... like dev, qa, prod
     id 'net.saliman.properties' version '1.4.6'
-
-    // this is the data hub framework gradle plugin
-    // it includes ml-gradle. This plugin is what lets you
-    // run DHF (Data Hub Framework) tasks from the
-    // command line
     id 'com.marklogic.ml-data-hub' version '2.0.0'
+}
+
+repositories {
+  jcenter()
+  maven { url "https://developer.marklogic.com/maven2/" }
+
+  ivy {
+    url 'http://download.geonames.org/'
+    layout 'pattern', {
+      artifact '/[organisation]/dump/[module].[ext]'
+    }
+  }
+}
+
+configurations {
+  mlcp
+  data
+}
+
+dependencies {
+  mlcp "com.marklogic:mlcp:9.0.2"
+  mlcp files("lib")
+  data "export:cities5000:*@zip"
 }
 
 task createXmlEntity(type: com.marklogic.gradle.task.CreateEntityTask) {
@@ -41,4 +57,94 @@ task createEntityInput() {
   dependsOn createInputJsonFlow
   finalizedBy mlLoadModules
   doLast { println "created XML and JSON entities and input flows" }
+}
+
+task getInputData() {
+  def headers = [
+    "geonameid",
+    "name",
+    "asciiname",
+    "alternatenames",
+    "latitude",
+    "longitude",
+    "feature class",
+    "feature code",
+    "country code",
+    "cc2",
+    "admin1 code",
+    "admin2 code",
+    "admin3 code",
+    "admin4 code",
+    "population",
+    "elevation",
+    "dem",
+    "timezone",
+    "modification date"
+  ]
+
+  def zipPath = project.configurations.data.find {
+    it.name.startsWith("cities5000")
+  }
+
+  doFirst {
+    mkdir "./input/"
+  }
+  doLast {
+    def zipFile = zipTree(file(zipPath)).getFiles().first()
+    def combined = new File('./input/raw.txt')
+    combined.text = headers.join("\t") + "\n" + zipFile.text
+  }
+}
+
+task prepareMlcpLog() {
+  mkdir "./lib/"
+  def props = new File('./lib/log4j.properties')
+  props.text = [
+    "log4j.rootLogger=INFO, stdout",
+    "log4j.appender.stdout=org.apache.log4j.ConsoleAppender",
+    "log4j.appender.stdout.Target=System.out",
+    "log4j.appender.stdout.layout=org.apache.log4j.PatternLayout",
+    "log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"
+  ].join("\n")
+}
+
+task loadJson(type: com.marklogic.gradle.task.MlcpTask) {
+  classpath = configurations.mlcp
+  command = "IMPORT"
+  database = mlStagingDbName
+  port = mlStagingPort.toInteger()
+  input_file_path = "./input/raw.txt"
+  delimiter = "\t"
+  input_file_type = "delimited_text"
+  document_type = "json"
+  output_uri_prefix = "/city/"
+  output_uri_suffix = ".json"
+  output_collections = "input-json"
+  transform_module = "/com.marklogic.hub/mlcp-flow-transform.xqy"
+  transform_namespace = "http://marklogic.com/data-hub/mlcp-flow-transform"
+  transform_param =  "entity-name=input-json,flow-name=raw-input-json"
+}
+
+task loadXml(type: com.marklogic.gradle.task.MlcpTask) {
+  classpath = configurations.mlcp
+  command = "IMPORT"
+  database = mlStagingDbName
+  port = mlStagingPort.toInteger()
+  input_file_path = "./input/raw.txt"
+  delimiter = "\t"
+  input_file_type = "delimited_text"
+  document_type = "xml"
+  output_uri_prefix = "/city/"
+  output_uri_suffix = ".xml"
+  output_collections = "input-xml"
+  transform_module = "/com.marklogic.hub/mlcp-flow-transform.xqy"
+  transform_namespace = "http://marklogic.com/data-hub/mlcp-flow-transform"
+  transform_param =  "entity-name=input-xml,flow-name=raw-input-xml"
+}
+
+task loadInputData {
+  mustRunAfter createEntityInput
+  dependsOn getInputData
+  dependsOn loadJson
+  dependsOn loadXml
 }

--- a/examples/performance-sample/build.gradle
+++ b/examples/performance-sample/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+    // this plugin lets you create properties files
+    // for multiple environments... like dev, qa, prod
+    id 'net.saliman.properties' version '1.4.6'
+
+    // this is the data hub framework gradle plugin
+    // it includes ml-gradle. This plugin is what lets you
+    // run DHF (Data Hub Framework) tasks from the
+    // command line
+    id 'com.marklogic.ml-data-hub' version '2.0.0'
+}

--- a/examples/performance-sample/build.gradle
+++ b/examples/performance-sample/build.gradle
@@ -9,3 +9,36 @@ plugins {
     // command line
     id 'com.marklogic.ml-data-hub' version '2.0.0'
 }
+
+task createXmlEntity(type: com.marklogic.gradle.task.CreateEntityTask) {
+  doFirst { project.ext.entityName = "input-xml" }
+}
+
+task createJsonEntity(type: com.marklogic.gradle.task.CreateEntityTask) {
+  doFirst { project.ext.entityName = "input-json" }
+}
+
+task createInputXmlFlow(type: com.marklogic.gradle.task.CreateInputFlowTask) {
+  doFirst {
+    project.ext.entityName = "input-xml"
+    project.ext.flowName = "raw-input-xml"
+    project.ext.dataFormat = "xml"
+  }
+}
+
+task createInputJsonFlow(type: com.marklogic.gradle.task.CreateInputFlowTask) {
+  doFirst {
+    project.ext.entityName = "input-json"
+    project.ext.flowName = "raw-input-json"
+    project.ext.dataFormat = "json"
+  }
+}
+
+task createEntityInput() {
+  dependsOn createXmlEntity
+  dependsOn createJsonEntity
+  dependsOn createInputXmlFlow
+  dependsOn createInputJsonFlow
+  finalizedBy mlLoadModules
+  doLast { println "created XML and JSON entities and input flows" }
+}

--- a/examples/performance-sample/build.gradle
+++ b/examples/performance-sample/build.gradle
@@ -120,10 +120,12 @@ task loadJson(type: com.marklogic.gradle.task.MlcpTask) {
   mustRunAfter mlLoadModules
   mustRunAfter getInputData
 
+  doFirst {
+    database = mlStagingDbName
+    port = mlStagingPort.toInteger()
+  }
   classpath = configurations.mlcp
   command = "IMPORT"
-  database = mlStagingDbName
-  port = mlStagingPort.toInteger()
   input_file_path = "./input/raw.txt"
   delimiter = "\t"
   input_file_type = "delimited_text"
@@ -141,10 +143,12 @@ task loadXml(type: com.marklogic.gradle.task.MlcpTask) {
   mustRunAfter mlLoadModules
   mustRunAfter getInputData
 
+  doFirst {
+    database = mlStagingDbName
+    port = mlStagingPort.toInteger()
+  }
   classpath = configurations.mlcp
   command = "IMPORT"
-  database = mlStagingDbName
-  port = mlStagingPort.toInteger()
   input_file_path = "./input/raw.txt"
   delimiter = "\t"
   input_file_type = "delimited_text"

--- a/examples/performance-sample/build.gradle
+++ b/examples/performance-sample/build.gradle
@@ -261,3 +261,43 @@ task doAll() {
   dependsOn loadInputData
   dependsOn allHarmonizeFlows
 }
+
+import java.util.concurrent.TimeUnit
+class TimingsListener implements TaskExecutionListener, BuildListener {
+  private long startTime
+  private timings = []
+
+  @Override
+  void beforeExecute(Task task) {
+    startTime = System.nanoTime()
+  }
+
+  @Override
+  void afterExecute(Task task, TaskState taskState) {
+    timings.add([
+      TimeUnit.MILLISECONDS.convert(System.nanoTime() -
+         startTime, TimeUnit.NANOSECONDS),
+      task.path
+    ])
+  }
+
+  @Override
+  void buildFinished(BuildResult result) {
+    println "Task timings:"
+    for (timing in timings)
+      printf "%10.3fs  %s\n", (timing[0] / 1000), timing[1]
+  }
+
+  @Override
+  void buildStarted(Gradle gradle) {}
+  @Override
+  void projectsEvaluated(Gradle gradle) {}
+  @Override
+  void projectsLoaded(Gradle gradle) {}
+  @Override
+  void settingsEvaluated(Settings settings) {}
+}
+
+if (project.hasProperty('profile')) {
+  gradle.addListener new TimingsListener()
+}


### PR DESCRIPTION
closes #492

All the details are in the README -- this should fulfill all the requirements in #492.

I used the geonames cities5000, this results in 45669 records, loaded first as XML and agains as JSON. (For some reason, "cities5000" contains 45677 records, and there's a handful of bad-character errors.) There's many similar geonames collections ranging dramatically in size, so it'd be easy to switch to a different source for shorter or longer testing.

On my MBP after running `hubInit` in an empty directory, `doAll` takes ~6 minutes (including a full, first-time `mlDeploy`). Here's the timing output with `-Pprofile`:

```
BUILD SUCCESSFUL in 6m 8s
21 actionable tasks: 21 executed
Task timings:
     2.742s  :hubPreInstallCheck
     0.001s  :mlDeleteModuleTimestampsFile
     0.004s  :mlPrepareRestApiDependencies
    88.791s  :mlDeployApp
     0.000s  :mlPostDeploy
     0.000s  :mlDeploy
     0.004s  :createJsonEntity
     0.002s  :createInputJsonFlow
     0.001s  :createXmlEntity
     0.002s  :createInputXmlFlow
     0.000s  :createEntityInput
     0.005s  :createHarmonizeJsonSjs
     0.003s  :createHarmonizeJsonXqy
     0.002s  :createHarmonizeXmlSjs
     0.002s  :createHarmonizeXmlXqy
     0.000s  :createHarmonizeFlows
     0.418s  :getInputData
     3.595s  :mlLoadModules
    52.553s  :loadJson
    52.685s  :loadXml
     0.003s  :loadInputData
    51.452s  :runHarmonizeJsonSjs
    29.802s  :runHarmonizeJsonXqy
    55.021s  :runHarmonizeXmlSjs
    30.660s  :runHarmonizeXmlXqy
     0.000s  :allHarmonizeFlows
     0.000s  :doAll
```

If you'd like to track timing over time (perhaps in a CI job), the [build-time-tracker-plugin](https://github.com/passy/build-time-tracker-plugin) seems superior to the add-hoc timing class in this PR, as it can append timing reports to a log.

And if the need arises to profile the data-hub implementation itself, there are many additional options that should be considered. A couple that stand out are the [gradle profiler](https://github.com/gradle/gradle-profiler), which has hooks for many different profiling packages, and [gradle build scans](https://guides.gradle.org/performance/#build-scan-performance), which appears to require (free) use of Gradle Cloud Services.