### PR TITLE
Issue413

### DIFF
--- a/quick-start/src/main/java/com/marklogic/quickstart/model/SearchPathModel.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/model/SearchPathModel.java
@@ -23,8 +23,8 @@ public class SearchPathModel {
 
 	public SearchPathModel(String name, String relativePath, String absolutePath) {
         this.name = name;
-		this.relativePath = relativePath;
-		this.absolutePath = absolutePath;
+        this.relativePath = relativePath;
+        this.absolutePath = absolutePath;
 	}
 
 }

--- a/quick-start/src/main/java/com/marklogic/quickstart/model/SearchPathModel.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/model/SearchPathModel.java
@@ -22,8 +22,9 @@ public class SearchPathModel {
 	public String absolutePath;
 
 	public SearchPathModel(String name, String relativePath, String absolutePath) {
+        this.name = name;
 		this.relativePath = relativePath;
 		this.absolutePath = absolutePath;
-		this.name = name;
 	}
+
 }

--- a/quick-start/src/main/java/com/marklogic/quickstart/util/FileUtil.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/util/FileUtil.java
@@ -18,6 +18,7 @@ package com.marklogic.quickstart.util;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.file.Path;
 
 public class FileUtil {
 
@@ -33,10 +34,15 @@ public class FileUtil {
         }
         return folders;
     }
+    public static List<String> listDirectFolders(String rootDirectoryName) {
+        return listDirectFolders(new File(rootDirectoryName));
+    }
+    public static List<String> listDirectFolders(Path rootDirectoryPath) {
+        return listDirectFolders(rootDirectoryPath.toFile());
+    }
 
-    public static List<String> listDirectFiles(String path) {
+    public static List<String> listDirectFiles(File rootDirectory) {
         List<String> filenames = new ArrayList<>();
-        File rootDirectory = new File(path);
         if (rootDirectory.exists() && rootDirectory.isDirectory()) {
             File[] files = rootDirectory.listFiles();
             for (File file : files) {
@@ -47,4 +53,11 @@ public class FileUtil {
         }
         return filenames;
     }
+    public static List<String> listDirectFiles(String rootDirectoryName) {
+        return listDirectFiles(new File(rootDirectoryName));
+    }
+    public static List<String> listDirectFiles(Path rootDirectoryPath) {
+        return listDirectFiles(rootDirectoryPath.toFile());
+    }
+
 }

--- a/quick-start/src/main/java/com/marklogic/quickstart/web/UtilController.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/web/UtilController.java
@@ -58,7 +58,7 @@ public class UtilController extends EnvironmentAware {
             paths.add(new SearchPathModel("..", relativePathStr, absolutePathStr));
         }
 
-        List<String> folders = FileUtil.listDirectFolders(relativePath.toFile());
+        List<String> folders = FileUtil.listDirectFolders(relativePath);
         for (String folder : folders) {
             Path childPath = relativePath.resolve(folder);
             String relativePathStr = currentPath.relativize(childPath).toString();
@@ -74,6 +74,7 @@ public class UtilController extends EnvironmentAware {
 		result.put("currentPath", relativePathStr);
 		result.put("currentAbsolutePath", relativePath.toString());
 		result.put("folders", paths);
+		result.put("files", FileUtil.listDirectFiles(relativePath));
 		return result;
 	}
 

--- a/quick-start/src/main/java/com/marklogic/quickstart/web/UtilController.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/web/UtilController.java
@@ -40,7 +40,8 @@ public class UtilController extends EnvironmentAware {
 	@ResponseBody
 	public Map<String, Object> searchPath(@RequestParam String path) {
 		logger.debug("Search Path:" + path);
-		List<SearchPathModel> paths = new ArrayList<>();
+		List<SearchPathModel> folders = new ArrayList<>();
+		List<SearchPathModel> files = new ArrayList<SearchPathModel>();
 		Path currentPath = Paths.get(".").toAbsolutePath().normalize();
 		Path relativePath;
 
@@ -55,16 +56,23 @@ public class UtilController extends EnvironmentAware {
         if (parent != null) {
             String relativePathStr = currentPath.relativize(parent).toString();
             String absolutePathStr = parent.toAbsolutePath().toString();
-            paths.add(new SearchPathModel("..", relativePathStr, absolutePathStr));
+            folders.add(new SearchPathModel("..", relativePathStr, absolutePathStr));
         }
 
-        List<String> folders = FileUtil.listDirectFolders(relativePath);
-        for (String folder : folders) {
+        for (String folder : FileUtil.listDirectFolders(relativePath)) {
             Path childPath = relativePath.resolve(folder);
             String relativePathStr = currentPath.relativize(childPath).toString();
             String absolutePathStr = childPath.toAbsolutePath().normalize().toString();
-            paths.add(new SearchPathModel(folder, relativePathStr, absolutePathStr));
+            folders.add(new SearchPathModel(folder, relativePathStr, absolutePathStr));
         }
+
+        for (String file : FileUtil.listDirectFiles(relativePath)) {
+            Path childPath = relativePath.resolve(file);
+            String relativePathStr = currentPath.relativize(childPath).toString();
+            String absolutePathStr = childPath.toAbsolutePath().normalize().toString();
+            files.add(new SearchPathModel(file, relativePathStr, absolutePathStr));
+        }
+
 
 		Map<String, Object> result = new HashMap<>();
         String relativePathStr = currentPath.relativize(relativePath).toString();
@@ -73,8 +81,8 @@ public class UtilController extends EnvironmentAware {
         }
 		result.put("currentPath", relativePathStr);
 		result.put("currentAbsolutePath", relativePath.toString());
-		result.put("folders", paths);
-		result.put("files", FileUtil.listDirectFiles(relativePath));
+		result.put("folders", folders);
+		result.put("files", files);
 		return result;
 	}
 

--- a/quick-start/src/main/resources/application.properties
+++ b/quick-start/src/main/resources/application.properties
@@ -3,7 +3,6 @@ server.port=${port:8080}
 server.contextPath=/
 # server.error.whitelabel.enabled=false
 logging.level.com.marklogic.hub=INFO
-logging.level.com.marklogic.quickstart.web=DEBUG
 logging.level.org.apache.catalina.webresources.Cache=ERROR
 logging.level.java.util.prefs=OFF
 spring.mvc.favicon.enabled=false

--- a/quick-start/src/main/resources/application.properties
+++ b/quick-start/src/main/resources/application.properties
@@ -3,6 +3,7 @@ server.port=${port:8080}
 server.contextPath=/
 # server.error.whitelabel.enabled=false
 logging.level.com.marklogic.hub=INFO
+logging.level.com.marklogic.quickstart.web=DEBUG
 logging.level.org.apache.catalina.webresources.Cache=ERROR
 logging.level.java.util.prefs=OFF
 spring.mvc.favicon.enabled=false

--- a/quick-start/src/main/ui/app/folder-browser/folder-browser.component.html
+++ b/quick-start/src/main/ui/app/folder-browser/folder-browser.component.html
@@ -14,7 +14,7 @@
         </div>
       </li>
       <li *ngFor="let file of files">
-        <div class="entry" (click)="fileSelected(file)">
+        <div class="entry" (click)="fileClicked(file)">
           <i class="fa fa-file-o"></i>
           <p>{{file.name}}</p>
         </div>

--- a/quick-start/src/main/ui/app/folder-browser/folder-browser.component.html
+++ b/quick-start/src/main/ui/app/folder-browser/folder-browser.component.html
@@ -8,9 +8,15 @@
     </div>
     <ul class="foldertree">
       <li *ngFor="let folder of folders">
-        <div class="entry" (click)="entryClicked(folder)">
+        <div class="entry" (click)="folderSelected(folder)">
           <i class="fa fa-folder-o"></i>
           <p>{{folder.name}}</p>
+        </div>
+      </li>
+      <li *ngFor="let file of files">
+        <div class="entry" (click)="fileSelected(file)">
+          <i class="fa fa-file-o"></i>
+          <p>{{file}}</p>
         </div>
       </li>
     </ul>

--- a/quick-start/src/main/ui/app/folder-browser/folder-browser.component.html
+++ b/quick-start/src/main/ui/app/folder-browser/folder-browser.component.html
@@ -8,7 +8,7 @@
     </div>
     <ul class="foldertree">
       <li *ngFor="let folder of folders">
-        <div class="entry" (click)="folderSelected(folder)">
+        <div class="entry" (click)="entryClicked(folder)">
           <i class="fa fa-folder-o"></i>
           <p>{{folder.name}}</p>
         </div>
@@ -16,7 +16,7 @@
       <li *ngFor="let file of files">
         <div class="entry" (click)="fileSelected(file)">
           <i class="fa fa-file-o"></i>
-          <p>{{file}}</p>
+          <p>{{file.name}}</p>
         </div>
       </li>
     </ul>

--- a/quick-start/src/main/ui/app/folder-browser/folder-browser.component.ts
+++ b/quick-start/src/main/ui/app/folder-browser/folder-browser.component.ts
@@ -11,6 +11,7 @@ import { MdlTextFieldComponent } from '@angular-mdl/core';
 export class FolderBrowserComponent implements OnInit, OnChanges {
   @Input() startPath: string = '.';
   @Output() folderChosen = new EventEmitter();
+  @Output() fileChosen = new EventEmitter();
   @Input() absoluteOnly: boolean = false;
 
   @ViewChild(MdlTextFieldComponent) inputPath: MdlTextFieldComponent;
@@ -70,8 +71,11 @@ export class FolderBrowserComponent implements OnInit, OnChanges {
     this.getFolders(entry.absolutePath);
   }
 
-  fileSelected(selectedFile: any) {
-    // Todo: need to fire event that tells MLCP command line to use this one file
+  fileClicked(selectedFile: any) {
+    this.fileChosen.emit( {
+      relativePath: selectedFile.currentPath,
+      absolutePath: selectedFile.absolutePath
+    })
   }
 
   private extractData(res: Response) {

--- a/quick-start/src/main/ui/app/folder-browser/folder-browser.component.ts
+++ b/quick-start/src/main/ui/app/folder-browser/folder-browser.component.ts
@@ -18,6 +18,7 @@ export class FolderBrowserComponent implements OnInit, OnChanges {
   currentPath: string = null;
   isLoading: boolean = false;
   folders: any[] = null;
+  files: any[] = null;
 
   constructor(private http: Http) {}
 
@@ -49,6 +50,7 @@ export class FolderBrowserComponent implements OnInit, OnChanges {
       .map(this.extractData)
       .subscribe(resp => {
         this.folders = resp.folders;
+        this.files = resp.files;
         this.currentPath = this.absoluteOnly ? resp.currentAbsolutePath : resp.currentPath;
         this.folderChosen.emit({
           relativePath: resp.currentPath,
@@ -64,8 +66,12 @@ export class FolderBrowserComponent implements OnInit, OnChanges {
     }
   }
 
-  entryClicked(entry: any): void {
+  folderSelected(entry: any): void {
     this.getFolders(entry.absolutePath);
+  }
+
+  fileSelected(selectedFile: any) {
+
   }
 
   private extractData(res: Response) {

--- a/quick-start/src/main/ui/app/folder-browser/folder-browser.component.ts
+++ b/quick-start/src/main/ui/app/folder-browser/folder-browser.component.ts
@@ -66,12 +66,12 @@ export class FolderBrowserComponent implements OnInit, OnChanges {
     }
   }
 
-  folderSelected(entry: any): void {
+  entryClicked(entry: any): void {
     this.getFolders(entry.absolutePath);
   }
 
   fileSelected(selectedFile: any) {
-
+    // Todo: need to fire event that tells MLCP command line to use this one file
   }
 
   private extractData(res: Response) {

--- a/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.html
+++ b/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.html
@@ -7,7 +7,7 @@
         <div class="group-section slideDown" flex layout="column" [ngClass]="getSectionClass('inputFiles')">
           <app-folder-browser
             [startPath]="startPath"
-            (folderChosen)="folderClicked($event)">
+            (folderChosen)="folderSelected($event)">
           </app-folder-browser>
         </div>
       </div>

--- a/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.html
+++ b/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.html
@@ -7,7 +7,8 @@
         <div class="group-section slideDown" flex layout="column" [ngClass]="getSectionClass('inputFiles')">
           <app-folder-browser
             [startPath]="startPath"
-            (folderChosen)="folderClicked($event)">
+            (folderChosen)="folderClicked($event)"
+            (fileChosen)="fileClicked($event)">
           </app-folder-browser>
         </div>
       </div>

--- a/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.html
+++ b/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.html
@@ -7,7 +7,7 @@
         <div class="group-section slideDown" flex layout="column" [ngClass]="getSectionClass('inputFiles')">
           <app-folder-browser
             [startPath]="startPath"
-            (folderChosen)="folderSelected($event)">
+            (folderChosen)="folderClicked($event)">
           </app-folder-browser>
         </div>
       </div>

--- a/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.ts
+++ b/quick-start/src/main/ui/app/mlcp-ui/mlcp-ui.component.ts
@@ -546,6 +546,13 @@ export class MlcpUiComponent implements OnChanges {
     }
   }
 
+  fileClicked(file: any): void {
+    if (this.inputFilePath != file.absolutePath) {
+      this.inputFilePath = file.absolutePath;
+      this.updateMlcpCommand();
+    }
+  }
+
   cmdCopied(): void {
     this.snackbar.showSnackbar({
       message: 'MLCP command copied to the clipboard.',


### PR DESCRIPTION
Basic functionality of displaying files in a selected directory, and being able to select one of those files and have it set as the input_file_path of MLCP. The URI replacement is still set to just the path name, minus the file name. The current folder display is set to just the folder, and does not display the file name. 

However, on a redisplay of the Flow, it will display the filename with its path in the Current Folder display. It will also not show the peer files in the file list, and instead just display the .. relative path as the only available option. It is also possible type in the file name in the Current Folder display, which works in setting the MLCP input_file_path, but is inconsistent with what I have it behaving as now.

The event model, and the relationship between the path displayed and the input_file_path, make this more complex than it seems at first. (I can go into detail elsewhere.) So before I "fix" these things, however, I'd like to discuss more what desired behavior we'd like. Do we allow multiple files? If so, how does that look? Do we want a separate display of the file name? Etc.

Meanwhile I believe this pull request contains the basic functionality requested, so I think it serves as a start at least for a candidate to be merged into the current development baseline.