### PR TITLE
Feature/delete hub

### DIFF
--- a/marklogic-data-hub/gradle.properties
+++ b/marklogic-data-hub/gradle.properties
@@ -24,9 +24,9 @@ mlTracePort=8012
 mlTraceDbName=data-hub-TRACING
 mlTraceForestsPerHost=1
 
-mlJobAppserverName=data-hub-JOB
+mlJobAppserverName=data-hub-JOBS
 mlJobPort=8013
-mlJobDbName=data-hub-JOB
+mlJobDbName=data-hub-JOBS
 mlJobForestsPerHost=1
 
 mlModulesDbName=data-hub-MODULES


### PR DESCRIPTION
On running a unit test that didn't clean up after itself, running "gradlew mlUndeploy" would fail, but 1) unit tests could clean up after themselves, and 2) "gradlew mlDeploy" followed by "gradlew mlUndeploy" worked fine. This turned out to be a difference in configuration. marklogic-data-hub/gradle.properties used "data-hub-JOB" as the name for the app serve and the database, but everywhere else they were "data-hub-JOBS". 