### PR TITLE
#591 - Show 2.0 features for server versions >= 9

### DIFF
--- a/quick-start/src/main/ui/app/header/header.component.html
+++ b/quick-start/src/main/ui/app/header/header.component.html
@@ -12,7 +12,7 @@
     <div class="mdl-layout-spacer"></div>
     <nav class="mdl-navigation mdl-layout--large-screen-only">
       <a id="database-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/')}" [routerLink]="['']"><i class="fa fa-dashboard"></i> Dashboard</a>
-      <a id="entities-tab" class="mdl-navigation__link" *ngIf="!getMarkLogicVersion().startsWith('8')" [ngClass]="{'active': isActive('/entities')}" [routerLink]="['entities']"><i class="fa fa-industry"></i> Entities</a>
+      <a id="entities-tab" class="mdl-navigation__link" *ngIf="getMarkLogicVersion() >= 9" [ngClass]="{'active': isActive('/entities')}" [routerLink]="['entities']"><i class="fa fa-industry"></i> Entities</a>
       <a id="flows-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/flows')}" [routerLink]="['flows']"><i class="mdi mdi-looks"></i> Flows</a>
       <a id="browser-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/browse')}" [routerLink]="['browse']"><i class="mdi mdi-magnify"></i> Browse Data</a>
       <a id="jobs-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/jobs')}" [routerLink]="['jobs']"><i class="fa fa-tasks"></i> <span *ngIf="getRunningJobCount() !== 0" [mdl-badge]="getRunningJobCount()">Jobs</span><span *ngIf="getRunningJobCount() === 0">Jobs</span></a>

--- a/quick-start/src/main/ui/app/header/header.component.html
+++ b/quick-start/src/main/ui/app/header/header.component.html
@@ -12,7 +12,7 @@
     <div class="mdl-layout-spacer"></div>
     <nav class="mdl-navigation mdl-layout--large-screen-only">
       <a id="database-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/')}" [routerLink]="['']"><i class="fa fa-dashboard"></i> Dashboard</a>
-      <a id="entities-tab" class="mdl-navigation__link" *ngIf="getMarkLogicVersion().startsWith('9')" [ngClass]="{'active': isActive('/entities')}" [routerLink]="['entities']"><i class="fa fa-industry"></i> Entities</a>
+      <a id="entities-tab" class="mdl-navigation__link" *ngIf="!getMarkLogicVersion().startsWith('8')" [ngClass]="{'active': isActive('/entities')}" [routerLink]="['entities']"><i class="fa fa-industry"></i> Entities</a>
       <a id="flows-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/flows')}" [routerLink]="['flows']"><i class="mdi mdi-looks"></i> Flows</a>
       <a id="browser-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/browse')}" [routerLink]="['browse']"><i class="mdi mdi-magnify"></i> Browse Data</a>
       <a id="jobs-tab" class="mdl-navigation__link" [ngClass]="{'active': isActive('/jobs')}" [routerLink]="['jobs']"><i class="fa fa-tasks"></i> <span *ngIf="getRunningJobCount() !== 0" [mdl-badge]="getRunningJobCount()">Jobs</span><span *ngIf="getRunningJobCount() === 0">Jobs</span></a>

--- a/quick-start/src/main/ui/app/header/header.component.ts
+++ b/quick-start/src/main/ui/app/header/header.component.ts
@@ -33,8 +33,9 @@ export class HeaderComponent {
     return this.jobListener.totalPercentComplete();
   }
 
-  getMarkLogicVersion(): string {
-    return this.envService.marklogicVersion;
+  getMarkLogicVersion(): number {
+    let version = this.envService.marklogicVersion.substr(0, this.envService.marklogicVersion.indexOf('.'));
+    return parseInt(version);
   }
 
   logout() {

--- a/quick-start/src/main/ui/app/new-flow/new-flow.component.html
+++ b/quick-start/src/main/ui/app/new-flow/new-flow.component.html
@@ -16,7 +16,7 @@
             label="{{flowType}} Flow Name (required)"
             #flowTypeInput="ngModel"
             [(ngModel)]="flow.flowName"></mdl-textfield>
-          <ng-template [ngIf]="!getMarkLogicVersion().startsWith('8')">
+          <ng-template [ngIf]="getMarkLogicVersion() >= 9">
             <label>Code Generation</label>
             <app-select-list
               [items]="scaffoldOptions"

--- a/quick-start/src/main/ui/app/new-flow/new-flow.component.html
+++ b/quick-start/src/main/ui/app/new-flow/new-flow.component.html
@@ -16,7 +16,7 @@
             label="{{flowType}} Flow Name (required)"
             #flowTypeInput="ngModel"
             [(ngModel)]="flow.flowName"></mdl-textfield>
-          <ng-template [ngIf]="getMarkLogicVersion().startsWith('9')">
+          <ng-template [ngIf]="!getMarkLogicVersion().startsWith('8')">
             <label>Code Generation</label>
             <app-select-list
               [items]="scaffoldOptions"

--- a/quick-start/src/main/ui/app/new-flow/new-flow.component.ts
+++ b/quick-start/src/main/ui/app/new-flow/new-flow.component.ts
@@ -51,7 +51,7 @@ export class NewFlowComponent {
     this.flow = _.clone(this.emptyFlow);
     this.actions = actions;
 
-    if (this.getMarkLogicVersion().startsWith('8')) {
+    if (this.getMarkLogicVersion() === 8) {
       this.flow.useEsModel = false;
     } else {
       if (flowType === 'INPUT') {
@@ -84,7 +84,8 @@ export class NewFlowComponent {
     this.hide();
   }
 
-  getMarkLogicVersion(): string {
-    return this.envService.marklogicVersion;
+  getMarkLogicVersion(): number {
+    let version = this.envService.marklogicVersion.substr(0, this.envService.marklogicVersion.indexOf('.'));
+    return parseInt(version);
   }
 }


### PR DESCRIPTION
This includes "Entities" link in header and "Code Generation" section in Create Flow dialog.
Check for version !== 8 rather than == 9.

Fixes #591 