### PR TITLE
Handle a null "range-path-index" value

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/lib/hub-entities.xqy
+++ b/marklogic-data-hub/src/main/resources/ml-modules/root/com.marklogic.hub/lib/hub-entities.xqy
@@ -108,7 +108,7 @@ declare function hent:dump-indexes($entities as json:array)
     return
       map:delete($o, $x)
   let $_ :=
-    for $idx in json:array-values(map:get($o, "range-path-index"))
+    for $idx in map:get($o, "range-path-index") ! json:array-values(.)
     return
       map:put($idx, "path-expression", fn:replace(map:get($idx, "path-expression"), "es:", "*:"))
   return


### PR DESCRIPTION
This is breaking the Harmonize Orders step in the tutorial.