### PR TITLE
Fixing Issue #409: add dynamic sizing to facets

### DIFF
--- a/quick-start/src/main/ui/app/facets/facets.component.html
+++ b/quick-start/src/main/ui/app/facets/facets.component.html
@@ -5,7 +5,7 @@
         mdl-colored="primary" mdl-button mdl-button-type="raised"
         *ngFor="let value of facet.values"
         (click)="toggle(facet.__key, value)">
-        <span title="{{ value.value }}">{{ facet.__key }}: {{ value | truncate:truncateLength }}</span>
+        <span class="chiclet-name" title="{{ value }}">{{ facet.__key }}: {{ value | truncate : 20 }}</span>
         <span class="fa fa-remove"></span>
       </button>
     </div>
@@ -16,7 +16,7 @@
       <ng-template [ngIf]="!isToggleCollapsed(facet.__key)">
         <div *ngFor="let value of facet.facetValues" class="facet-value" (click)="toggle(facet.__key, value.name)">
           <i class="fa fa-plus-circle facet-add-pos"></i>
-          <span *ngIf="!!value.name" title="{{ value.name }}">{{ value.name | truncate : truncateLength }}</span>
+          <span *ngIf="!!value.name" title="{{ value.name }}" [ngClass]='{"facet-small-name": value.name.length > 17}'>{{ value.name | truncate : 30 }}</span>
           <em *ngIf="!value.name">blank</em>
           <span class="badge" [mdl-badge]="value.count"></span>
           <i class="fa fa-ban facet-add-neg" *ngIf="shouldNegate" (click)="negate({facet: facet.__key, value: value.name})" title="{{ value.name }}"></i>

--- a/quick-start/src/main/ui/app/facets/facets.component.scss
+++ b/quick-start/src/main/ui/app/facets/facets.component.scss
@@ -20,15 +20,22 @@ $bg-color: unquote("rgb(#{$palette-datahub-500})");
     .fa {
       float: right;
       font-weight: bold;
+      font-size: 11px;
     }
   }
 
   .facet-value {
-    padding: 10px;
+    padding: 2px;
+    padding-top: 10px;
     cursor: pointer;
 
     .fa {
       color: $bg-color;
+      font-size: 11px;
+    }
+
+    .facet-small-name {
+      font-size: .59vw;
     }
 
     .mdl-badge {
@@ -52,6 +59,10 @@ $bg-color: unquote("rgb(#{$palette-datahub-500})");
   button {
     font-size: 10px;
     margin-bottom: 5px;
+
+    .chiclet-name {
+        font-size: .54vw;
+    }
   }
 
   margin-bottom: 10px;


### PR DESCRIPTION
To resolve the issue of long collection names wrapping, then
the facet will utilize a different style class so the text is
smaller and will appear in a single line.  The facet value length
will be compared to determine if the custom class will be utilized
or not.

Added similar logic to the chiclet since the previous chiclets
were not being displayed properly, all the UI would show was
"Collection:" and you would not be able to see any text.  Added
hover over tooltip for the chiclet values so that the user can
see the full facet name.