### PR TITLE
Test on other hosts

### DIFF
--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -236,6 +236,7 @@ public class HubTestBase {
         hubConfig.setJobPort(jobPort);
         hubConfig.getAppConfig().setAppServicesUsername(user);
         hubConfig.getAppConfig().setAppServicesPassword(password);
+        hubConfig.getAppConfig().setHost(host);
         return hubConfig;
     }
 


### PR DESCRIPTION
This is just a change to the test setup for quickstart.  Now, it will honor the property in gradle.properties rather than just running on localhost.