### PR TITLE
Add --disable-host-check to allow external access

### DIFF
--- a/quick-start/package.json
+++ b/quick-start/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "rimraf": "rimraf",
     "ng": "ng",
-    "start": "ng serve -pc proxy.config.json --host 0.0.0.0",
+    "start": "ng serve -pc proxy.config.json --host 0.0.0.0 --disable-host-check",
     "clean.dist": "npm run rimraf -- dist",
     "build.prod": "npm run clean.dist && ng build -prod",
     "test": "ng test",


### PR DESCRIPTION
When installing and running QuickStart on an ML VM, I couldn't access that QuickStart app from my remote machine, i.e. via:

http://engrlab-129-036.engrlab.marklogic.com:4200/

Adding --disable-host-check to the "ng serve" command fixed this:

`ng serve -pc proxy.config.json --host 0.0.0.0 --disable-host-check`

This is discussed here:

https://stackoverflow.com/questions/43677629/invalid-host-header-when-running-angular-cli-development-server-c9-io

There are reported security implications:

https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a

Note that I was not able to solve the issue by adding a --public option (with marklogic.com or *.marklogic.com) instead, which is mentioned in the above article.