### PR TITLE
Remove mimetypes from deployed configuration #780

### DIFF
--- a/marklogic-data-hub/src/main/resources/ml-config/mimetypes/woff.json
+++ b/marklogic-data-hub/src/main/resources/ml-config/mimetypes/woff.json
@@ -1,7 +1,0 @@
-{
-  "name": "application/font-woff",
-  "extension": [
-    "woff"
-  ],
-  "format": "binary"
-}

--- a/marklogic-data-hub/src/main/resources/ml-config/mimetypes/woff2.json
+++ b/marklogic-data-hub/src/main/resources/ml-config/mimetypes/woff2.json
@@ -1,7 +1,0 @@
-{
-  "name": "application/font-woff2",
-  "extension": [
-    "woff2"
-  ],
-  "format": "binary"
-}


### PR DESCRIPTION
This change just removes mimetypes from a default data hub.  the mimetypes are present in server 9.0-5 out of the box.