### PR TITLE
DHFPROD-466 Improving tests for quickstart host config

### DIFF
--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -297,9 +297,10 @@ task collectorTest(type: Test, dependsOn: testClasses) {
 //}
 
 test {
-    // we exclude the StreamCollectorTest
-    exclude '**/StreamCollector*'
-	//dependsOn tasks.createLocalFile
-    // depend on the collectorTest task above
-    dependsOn tasks.collectorTest
+    //dependsOn tasks.collectorTest
+
+    // the core test suite runs these tests, so exclude them here.
+    include 'com/marklogic/hub/CoreTestSuite.class'
+    include 'com/marklogic/hub/EndToEndFlowTests.class'
+    include 'com/marklogic/hub/ScaffoldingE2E.class'
 }

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -288,7 +288,7 @@ test {
     minHeapSize = "128m"
     maxHeapSize = "256m"
 
-    // the core test suite runs these tests, so exclude them here.
+    // include just the three top-level tests.  they include setup/teardown
     include 'com/marklogic/hub/CoreTestSuite.class'
     include 'com/marklogic/hub/EndToEndFlowTests.class'
     include 'com/marklogic/hub/ScaffoldingE2E.class'

--- a/marklogic-data-hub/build.gradle
+++ b/marklogic-data-hub/build.gradle
@@ -252,18 +252,6 @@ ext {
     }
 }
 
-// for the StreamCollectorTest we need to constrain the memory
-// to a lower value so that the out of memory issue appears
-// the hack here is to run that single test in this task with
-// the appropriate memory constraints. This task is a dependency
-// of the regular test task and thus gets run right before all
-// of the other tests run.
-task collectorTest(type: Test, dependsOn: testClasses) {
-    include '**/StreamCollector*'
-    minHeapSize = "128m"
-    maxHeapSize = "256m"
-}
-
 //task createLocalFile() {
 //	boolean sslRun = Boolean.parseBoolean(System.properties['ssl'])
 //	boolean certAuth = Boolean.parseBoolean(System.properties['certauth'])
@@ -297,7 +285,8 @@ task collectorTest(type: Test, dependsOn: testClasses) {
 //}
 
 test {
-    //dependsOn tasks.collectorTest
+    minHeapSize = "128m"
+    maxHeapSize = "256m"
 
     // the core test suite runs these tests, so exclude them here.
     include 'com/marklogic/hub/CoreTestSuite.class'

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
@@ -26,14 +26,18 @@ import com.marklogic.hub.job.Job;
 import com.marklogic.hub.job.JobManager;
 import com.marklogic.hub.job.JobStatus;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 public class MlcpRunner extends ProcessRunner {
 
+    private static Logger logger = LoggerFactory.getLogger(MlcpRunner.class);
     private JobManager jobManager;
     private Flow flow;
     private JsonNode mlcpOptions;
@@ -171,6 +175,15 @@ public class MlcpRunner extends ProcessRunner {
                 File.separator + "java";
             String classpath = System.getProperty("java.class.path");
 
+            // strip out non-essential entries to truncate classpath
+            List<String> classpathEntries = Arrays.asList(classpath.split(File.pathSeparator));
+            String filteredClasspathEntries = classpathEntries
+                            .stream()
+                            .filter(
+                                u -> (!u.contains("spring")))
+                            .collect(Collectors.joining(File.pathSeparator));
+
+
             File loggerFile = File.createTempFile("mlcp-", "-logger.xml");
             FileUtils.writeStringToFile(loggerFile, buildLoggerconfig());
 
@@ -183,7 +196,7 @@ public class MlcpRunner extends ProcessRunner {
             }
             else {
                 args.add("-cp");
-                args.add(classpath);
+                args.add(filteredClasspathEntries);
                 args.add(mainClass);
             }
         }

--- a/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
+++ b/marklogic-data-hub/src/main/java/com/marklogic/hub/util/MlcpRunner.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 public class MlcpRunner extends ProcessRunner {
@@ -175,14 +176,31 @@ public class MlcpRunner extends ProcessRunner {
                 File.separator + "java";
             String classpath = System.getProperty("java.class.path");
 
+            //logger.warn("Classpath before is: " + classpath);
             // strip out non-essential entries to truncate classpath
             List<String> classpathEntries = Arrays.asList(classpath.split(File.pathSeparator));
             String filteredClasspathEntries = classpathEntries
                             .stream()
                             .filter(
-                                u -> (!u.contains("spring")))
+                                u -> (
+                                    u.contains("jdk") ||
+                                    u.contains("jre") ||
+                                    u.contains("log") ||
+                                    u.contains("xml") ||
+                                    u.contains("json") ||
+                                    u.contains("slf") ||
+                                    u.contains("mlcp") ||
+                                    u.contains("xcc") ||
+                                    u.contains("data-hub") ||
+                                    u.contains("mapreduce") ||
+                                    u.contains("google") ||
+                                    u.contains("apache") ||
+                                    u.contains("commons") ||
+                                    u.contains("hadoop"))
+                            )
                             .collect(Collectors.joining(File.pathSeparator));
 
+            //logger.warn("Classpath filtered to: " + filteredClasspathEntries);
 
             File loggerFile = File.createTempFile("mlcp-", "-logger.xml");
             FileUtils.writeStringToFile(loggerFile, buildLoggerconfig());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/CoreTestSuite.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/CoreTestSuite.java
@@ -1,0 +1,60 @@
+package com.marklogic.hub;
+
+
+import com.marklogic.hub.collector.DiskQueueTest;
+import com.marklogic.hub.collector.EmptyCollectorTest;
+import com.marklogic.hub.collector.StreamCollectorTest;
+import com.marklogic.hub.core.*;
+import com.marklogic.hub.deploy.commands.GenerateHubTDETemplateCommandTest;
+import com.marklogic.hub.deploy.commands.LoadUserModulesCommandTest;
+import com.marklogic.hub.entity.EntityManagerTest;
+import com.marklogic.hub.flow.FlowManagerTest;
+import com.marklogic.hub.flow.FlowRunnerTest;
+import com.marklogic.hub.job.JobManagerTest;
+import com.marklogic.hub.job.TracingTest;
+import com.marklogic.hub.scaffolding.ScaffoldingTest;
+import com.marklogic.hub.scaffolding.ScaffoldingValidatorTest;
+import com.marklogic.hub.util.Installer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses( {
+    DiskQueueTest.class,
+    EmptyCollectorTest.class,
+    StreamCollectorTest.class,
+    DataHubInstallTest.class,
+    DataHubTest.class,
+    DebugLibTest.class,
+    HubConfigTest.class,
+    HubProjectTest.class,
+    GenerateHubTDETemplateCommandTest.class,
+    LoadUserModulesCommandTest.class,
+    EntityManagerTest.class,
+    FlowManagerTest.class,
+    FlowRunnerTest.class,
+    JobManagerTest.class,
+    TracingTest.class,
+    // these two must be run separately!
+    //EndToEndFlowTests.class,
+    //ScaffoldingE2E.class,
+    ScaffoldingTest.class,
+    ScaffoldingValidatorTest.class
+})
+
+public class CoreTestSuite {
+
+    @BeforeClass
+    public static void setUp() {
+        new Installer().installHubOnce();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        new Installer().uninstallHub();
+    }
+
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/EndToEndFlowTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.hub.jupiterbased;
+package com.marklogic.hub;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -24,10 +24,6 @@ import com.marklogic.client.datamovement.JobTicket;
 import com.marklogic.client.datamovement.WriteBatcher;
 import com.marklogic.client.document.GenericDocumentManager;
 import com.marklogic.client.document.ServerTransform;
-import com.marklogic.hub.DataHub;
-import com.marklogic.hub.FlowManager;
-import com.marklogic.hub.HubConfig;
-import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.scaffold.Scaffolding;
 import com.marklogic.hub.util.FileUtil;
 import com.marklogic.hub.util.Installer;
@@ -128,14 +124,22 @@ public class EndToEndFlowTests extends HubTestBase {
 
     private Scaffolding scaffolding;
 
-    @BeforeEach
-    public void setup() {
+    @BeforeAll
+    public static void setup() {
         XMLUnit.setIgnoreWhitespace(true);
-        //new Installer().installHubOnce();
-        //deleteProjectDir();
-        if(isSslRun() || isCertAuth()) {
-     		sslSetup();
-		}
+        new Installer().installHubOnce();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        new Installer().uninstallHub();
+    }
+
+    @BeforeEach
+    public void setupEach() {
+        if (isSslRun() || isCertAuth()) {
+            sslSetup();
+        }
 
         clearDatabases();
         createProjectDir();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -49,6 +49,7 @@ import com.marklogic.hub.jupiterbased.ComboListener;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.json.JSONException;
 import org.junit.After;
@@ -104,6 +105,8 @@ import com.marklogic.mgmt.util.ObjectMapperFactory;
 import com.marklogic.rest.util.JsonNodeUtil;
 
 
+// FIXME remove deprecated methods
+@SuppressWarnings(value="deprecation")
 public class HubTestBase {
 
     // to speedup dev cycle, you can create a hub and set this to true.
@@ -122,7 +125,6 @@ public class HubTestBase {
     public  int jobPort;
     public  String user;
     public  String password;
-    // FIXME deprecated methods
     protected  Authentication stagingAuthMethod;
     private  Authentication finalAuthMethod;
     private  Authentication traceAuthMethod;
@@ -176,10 +178,10 @@ public class HubTestBase {
 
     protected void basicSetup() {
         XMLUnit.setIgnoreWhitespace(true);
-        installHubOnce();
+        createProjectDir();
     }
 
-    private void init() {
+    protected void init() {
         try {
             Properties p = new Properties();
             p.load(new FileInputStream("gradle.properties"));
@@ -336,7 +338,7 @@ public class HubTestBase {
         return getHubConfig(PROJECT_PATH);
     }
 
-    protected DataHub getDataHub() {
+    public DataHub getDataHub() {
         return DataHub.create(getHubConfig());
     }
 
@@ -402,17 +404,7 @@ public class HubTestBase {
         }
     }
 
-    protected void installHubOnce() {
-        createProjectDir();
-        if (!isInstalled) {
-            nInstalls++;
-            logger.warn("Installing the hub.  Hit this block " + nInstalls + " times this run.");
-            getDataHub().install();
-            isInstalled = true;
-        }
-    }
-
-    protected void deleteProjectDir() {
+    public void deleteProjectDir() {
         if (new File(PROJECT_PATH).exists()) {
             try {
                 FileUtils.forceDelete(new File(PROJECT_PATH));
@@ -421,15 +413,6 @@ public class HubTestBase {
             }
         }
     }
-
-    protected void uninstallHub() {
-        if (isInstalled) {
-            getDataHub().uninstall();
-        }
-        deleteProjectDir();
-        isInstalled = false;
-    }
-
     protected File getResourceFile(String resourceName) {
         return new File(HubTestBase.class.getClassLoader().getResource(resourceName).getFile());
     }
@@ -890,7 +873,7 @@ public class HubTestBase {
         adminManager = new com.marklogic.mgmt.admin.AdminManager(adminConfig);
 	}
 
-	protected  void sslCleanup() {
+	public  void sslCleanup() {
 	    Path localPath = getResourceFile("scaffolding/gradle-local_properties").toPath();
 	    String localProps = new String("# Put your overrides from gradle.properties here\n" +
 	    		"# Don't check this in to version control\n" +
@@ -1012,24 +995,6 @@ public class HubTestBase {
         }
     }
 
-    // I think this can be a teardown for every test.
-    // rather than part of setup.
-    @After
-    public void teardownConfig() throws IOException {
-        deleteProjectDir();
-    }
-
-
-
-    @AfterClass
-    public static void teardown() {
-        logger.warn("Tearing down the hub.  Install was called " + nInstalls + " times so far.");
-        HubTestBase htb = new HubTestBase();
-        htb.uninstallHub();
-        if(htb.isSslRun() || htb.isCertAuth()) {
-            htb.sslCleanup();
-        }
-    }
 }
 
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/HubTestBase.java
@@ -45,15 +45,12 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import com.marklogic.hub.error.DataHubConfigurationException;
-import com.marklogic.hub.jupiterbased.ComboListener;
+import com.marklogic.hub.util.ComboListener;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.json.JSONException;
-import org.junit.After;
-import org.junit.AfterClass;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/ScaffoldingE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/ScaffoldingE2E.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.hub.jupiterbased;
+package com.marklogic.hub;
 
 import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.flow.CodeFormat;
@@ -21,12 +21,10 @@ import com.marklogic.hub.flow.DataFormat;
 import com.marklogic.hub.flow.FlowType;
 import com.marklogic.hub.scaffold.impl.ScaffoldingImpl;
 import com.marklogic.hub.util.FileUtil;
+import com.marklogic.hub.util.Installer;
 import org.apache.commons.io.FileUtils;
 import org.custommonkey.xmlunit.XMLUnit;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.*;
 import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.xml.sax.SAXException;
@@ -50,9 +48,19 @@ public class ScaffoldingE2E extends HubTestBase {
     private static File projectDir = projectPath.toFile();
     private static File pluginDir = projectPath.resolve("plugins").toFile();
 
+    @BeforeAll
+    public static void setupHub() {
+        XMLUnit.setIgnoreWhitespace(true);
+        new Installer().installHubOnce();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        new Installer().uninstallHub();
+    }
+
     @BeforeEach
     public void setup() throws IOException {
-        XMLUnit.setIgnoreWhitespace(true);
         deleteProjectDir();
 
         createProjectDir();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/collector/EmptyCollectorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/collector/EmptyCollectorTest.java
@@ -49,8 +49,6 @@ public class EmptyCollectorTest extends HubTestBase {
 
         createProjectDir();
 
-        installHubOnce();
-
         Scaffolding scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
         scaffolding.createEntity(ENTITY);
         scaffolding.createFlow(ENTITY, "testharmonize", FlowType.HARMONIZE,

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/collector/StreamCollectorTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/collector/StreamCollectorTest.java
@@ -68,7 +68,7 @@ public class StreamCollectorTest extends HubTestBase {
         dbDir.toFile().mkdirs();
         FileUtil.copy(getResourceStream("stream-collector-test/staging-database.json"), dbDir.resolve("staging-database.json").toFile());
 
-        installHubOnce();
+        createProjectDir();
 
         // disable tracing because trying to trace the 3 million ids to a doc will fail.
         disableDebugging();
@@ -81,7 +81,8 @@ public class StreamCollectorTest extends HubTestBase {
 
         DataHub dh = DataHub.create(getHubConfig());
         dh.clearUserModules();
-        installUserModules(getHubConfig(), false);
+        installUserModules(getHubConfig(), true);
+        getDataHub().updateIndexes();
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_TRACE_NAME, HubConfig.DEFAULT_JOB_NAME);
 
         installModule("/entities/" + ENTITY + "/harmonize/testharmonize/collector.xqy", "stream-collector-test/collector.xqy");

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/DataHubInstallTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/DataHubInstallTest.java
@@ -21,6 +21,7 @@ import com.marklogic.client.ext.modulesloader.impl.PropertiesModuleManager;
 import com.marklogic.hub.DataHub;
 import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
+import com.marklogic.hub.impl.DataHubImpl;
 import com.marklogic.hub.util.Versions;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class DataHubInstallTest extends HubTestBase {
         // the project dir must be available for uninstall to do anything... interesting.
         createProjectDir();
         if (!setupDone) getDataHub().uninstall();
-        if (!setupDone) installHubOnce();
+        if (!setupDone) getDataHub().install();
         setupDone=true;
         afterTelemetryInstallCount = getTelemetryInstallCount();
     }

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/core/HubProjectTest.java
@@ -5,6 +5,7 @@ import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -20,6 +21,10 @@ public class HubProjectTest extends HubTestBase {
 
     private static File projectPath = new File(PROJECT_PATH);
 
+    @Before
+    public void setupDir() {
+        deleteProjectDir();
+    }
 
     @Test
     public void testInit() throws IOException {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/entity/EntityManagerTest.java
@@ -40,12 +40,8 @@ public class EntityManagerTest extends HubTestBase {
     private static File projectDir = projectPath.toFile();
 
     @Before
-    public void setup() {
-        basicSetup();
-    }
-
-    @Before
     public void clearDbs() {
+        deleteProjectDir();
         basicSetup();
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_MODULES_DB_NAME);
         installHubModules();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/flow/FlowRunnerTest.java
@@ -45,7 +45,7 @@ public class FlowRunnerTest extends HubTestBase {
 
         deleteProjectDir();
 
-        installHubOnce();
+        createProjectDir();
 
         enableDebugging();
         enableTracing();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/job/JobManagerTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/job/JobManagerTest.java
@@ -56,7 +56,7 @@ public class JobManagerTest extends HubTestBase {
         XMLUnit.setIgnoreWhitespace(true);
         deleteProjectDir();
 
-        installHubOnce();
+        createProjectDir();
 
         enableDebugging();
         enableTracing();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/job/TracingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/job/TracingTest.java
@@ -53,46 +53,25 @@ public class TracingTest extends HubTestBase {
     private static final String BINARY_HEX_ENCODED_XQY = "89504e470d0a1a0a0000000d494844520000000d0000001308060000004b378797000000017352474200aece1ce900000006624b474400ff00ff00ffa0bda793000000097048597300000b1300000b1301009a9c180000000774494d4507da0811012332d018a204000002af4944415428cf9592cb6e1c4500454f555757573fc6f3308e9f40ac286c909122082b36acf317ec59b2e4a7f8098422a17889402436a3d8c61ecfabbba7bbebc502943d573afb239d2bbeffe1c7d7428849aa539565d9814a9298ea340a04ce39a15325807bebbccb8d591963be534aabaf46d98caa2c383898b13fdb23cd6054569455c5fe74c2d9c95159b73b16cb3521c673a9303c7966397aeee9d47bfe5afc815639c664e42623d50a21252a4970ced1b4bb4e4a34c5f192a75f248cceeff8fdfe35432bf13e60ad63182c2104ac7338ef8921a02c35b7bf1e53ff2610ea635e9c5e90950e44865209b9314829d15a93e7062913a9bc77d44d438c91e9788cd18675bdc5c788f39ec7e58af5664bbbeb98dfdc320cb6550021044288586769bb0e1f5204026b2d006591635d40a72926334a299532998cd199444a49a14b9e1c8d1915157b7b15fbfb5366d329fd60b9b9bb67d7f7a954b1e2f0c50d2f5fc1f4e22dbf5cff44b791f8e0e9074bddb48410e8fb9eaeefb1838dcac78ef575c9add30ced8cd3598e5001008440fe479224a4a98288508e8e873fa7ec6e2db3e909cf8ff791da12a2012211e807cb765bf3f0b0a06e765e451fb1b1c14618a2e261e5c8bb9cb6ed596d362c168fbcbb9e7f501dac8b4a2a8949a648afc06ac6e50c530acabca42c4baaaae4ecf888c13996eb2d314425534a0e2f167cfeada338fb9babd51b525191e739459e331e555455894e53acb5f4d646e93de8d23239481145cd7cf1166f81183fdce7df8e81444a887150cbe68eab9f3fe5fe32a0d353befee44bcc28a0544296698a3c474a496e0c7be3316f2e2fbf519f3d3b6f04b2cc32c5a82cf00cdc3f3cd2343bd6db86f56643bbdbd1b41d8be5aadf6eeb97eae4a3c92ba1d2a70879e87c98eefabe68ba906cb60d4a253ed5babb9ebf5f393bdcd59bf595526a2e628cfcdffd03c6146669f7b691ab0000000049454e44ae426082";
     private static final String BINARY_HEX_ENCODED_SJS = "BinaryNode(\"89504e470d0a1a0a0000000d494844520000000d0000001308060000004b378797000000017352474200aece1ce900000006624b474400ff00ff00ffa0bda793000000097048597300000b1300000b1301009a9c180000000774494d4507da0811012332d018a204000002af4944415428cf9592cb6e1c4500454f555757573fc6f3308e9f40ac286c909122082b36acf317ec59b2e4a7f8098422a17889402436a3d8c61ecfabbba7bbebc502943d573afb239d2bbeffe1c7d7428849aa539565d9814a9298ea340a04ce39a15325807bebbccb8d591963be534aabaf46d98caa2c383898b13fdb23cd6054569455c5fe74c2d9c95159b73b16cb3521c673a9303c7966397aeee9d47bfe5afc815639c664e42623d50a21252a4970ced1b4bb4e4a34c5f192a75f248cceeff8fdfe35432bf13e60ad63182c2104ac7338ef8921a02c35b7bf1e53ff2610ea635e9c5e90950e44865209b9314829d15a93e7062913a9bc77d44d438c91e9788cd18675bdc5c788f39ec7e58af5664bbbeb98dfdc320cb6550021044288586769bb0e1f5204026b2d006591635d40a72926334a299532998cd199444a49a14b9e1c8d1915157b7b15fbfb5366d329fd60b9b9bb67d7f7a954b1e2f0c50d2f5fc1f4e22dbf5cff44b791f8e0e9074bddb48410e8fb9eaeefb1838dcac78ef575c9add30ced8cd3598e5001008440fe479224a4a98288508e8e873fa7ec6e2db3e909cf8ff791da12a2012211e807cb765bf3f0b0a06e765e451fb1b1c14618a2e261e5c8bb9cb6ed596d362c168fbcbb9e7f501dac8b4a2a8949a648afc06ac6e50c530acabca42c4baaaae4ecf888c13996eb2d314425534a0e2f167cfeada338fb9babd51b525191e739459e331e555455894e53acb5f4d646e93de8d23239481145cd7cf1166f81183fdce7df8e81444a887150cbe68eab9f3fe5fe32a0d353befee44bcc28a0544296698a3c474a496e0c7be3316f2e2fbf519f3d3b6f04b2cc32c5a82cf00cdc3f3cd2343bd6db86f56643bbdbd1b41d8be5aadf6eeb97eae4a3c92ba1d2a70879e87c98eefabe68ba906cb60d4a253ed5babb9ebf5f393bdcd59bf595526a2e628cfcdffd03c6146669f7b691ab0000000049454e44ae426082\")";
 
-    private static final List<DatabaseClient> clients = new ArrayList<DatabaseClient>();
-
+    
     @Before
     public void setup() throws IOException, URISyntaxException {
         basicSetup();
 
         enableDebugging();
-
-        clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME);
+        clearDatabases(HubConfig.DEFAULT_STAGING_NAME,  HubConfig.DEFAULT_TRACE_NAME, HubConfig.DEFAULT_FINAL_NAME);
 
         URL url = TracingTest.class.getClassLoader().getResource("tracing-test");
         String path = Paths.get(url.toURI()).toFile().getAbsolutePath();
         installUserModules(getHubConfig(path), true);
 
-        ManageClient manageClient = ((HubConfigImpl)getHubConfig()).getManageClient();
-        String resp = manageClient.getJson("/manage/v2/hosts?format=json");
-        JsonNode actualObj = new ObjectMapper().readTree(resp);
-		JsonNode nameNode = actualObj.path("host-default-list").path("list-items");
-		List<String> hosts = nameNode.findValuesAsText("nameref");
-		hosts.forEach(serverHost ->
-		{
-			try {
-				clients.add(getClient(serverHost, stagingPort, HubConfig.DEFAULT_STAGING_NAME, user, password, stagingAuthMethod));
-			} catch (Exception e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-		});
+       
      }
 
-    @Before
+    @After
     public void beforeEach() {
+    	disableTracing();
         clearDatabases(HubConfig.DEFAULT_JOB_NAME, HubConfig.DEFAULT_TRACE_NAME, HubConfig.DEFAULT_FINAL_NAME);
-        Tracing.create(stagingClient).disable();
-        clients.forEach(client ->
-		{
-			client.newServerEval().xquery("xquery version \"1.0-ml\";\n" +
-					"import module namespace hul = \"http://marklogic.com/data-hub/hub-utils-lib\" at \"/MarkLogic/data-hub-framework/impl/hub-utils-lib.xqy\";\n" +
-					"hul:invalidate-field-cache(\"tracing-enabled\")").eval();
-		});
     }
 
 
@@ -148,7 +127,7 @@ public class TracingTest extends HubTestBase {
         Tracing t = Tracing.create(stagingClient);
         assertFalse(t.isEnabled());
 
-        t.enable();
+        enableTracing();
         assertTrue(t.isEnabled());
 
         FlowManager fm = FlowManager.create(getHubConfig());
@@ -173,7 +152,7 @@ public class TracingTest extends HubTestBase {
         Tracing t = Tracing.create(stagingClient);
         assertFalse(t.isEnabled());
 
-        t.enable();
+        enableTracing();
         assertTrue(t.isEnabled());
 
         FlowManager fm = FlowManager.create(getHubConfig());
@@ -210,7 +189,7 @@ public class TracingTest extends HubTestBase {
         Tracing t = Tracing.create(stagingClient);
         assertFalse(t.isEnabled());
 
-        t.enable();
+        enableTracing();
         assertTrue(t.isEnabled());
 
         FlowManager fm = FlowManager.create(getHubConfig());
@@ -247,7 +226,7 @@ public class TracingTest extends HubTestBase {
         Tracing t = Tracing.create(stagingClient);
         assertFalse(t.isEnabled());
 
-        t.enable();
+        enableTracing();
         assertTrue(t.isEnabled());
 
         FlowManager fm = FlowManager.create(getHubConfig());
@@ -273,7 +252,7 @@ public class TracingTest extends HubTestBase {
         Tracing t = Tracing.create(stagingClient);
         assertFalse(t.isEnabled());
 
-        t.enable();
+        enableTracing();
         assertTrue(t.isEnabled());
 
         FlowManager fm = FlowManager.create(getHubConfig());
@@ -309,7 +288,7 @@ public class TracingTest extends HubTestBase {
         Tracing t = Tracing.create(stagingClient);
         assertFalse(t.isEnabled());
 
-        t.enable();
+        enableTracing();
         assertTrue(t.isEnabled());
 
         FlowManager fm = FlowManager.create(getHubConfig());

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/jupiterbased/EndToEndFlowTests.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/jupiterbased/EndToEndFlowTests.java
@@ -30,6 +30,7 @@ import com.marklogic.hub.HubConfig;
 import com.marklogic.hub.HubTestBase;
 import com.marklogic.hub.scaffold.Scaffolding;
 import com.marklogic.hub.util.FileUtil;
+import com.marklogic.hub.util.Installer;
 import com.marklogic.hub.util.MlcpRunner;
 import com.marklogic.hub.validate.EntitiesValidator;
 import org.apache.commons.io.FileUtils;
@@ -130,18 +131,21 @@ public class EndToEndFlowTests extends HubTestBase {
     @BeforeEach
     public void setup() {
         XMLUnit.setIgnoreWhitespace(true);
-        //uninstallHub();
-        deleteProjectDir();
+        //new Installer().installHubOnce();
+        //deleteProjectDir();
         if(isSslRun() || isCertAuth()) {
      		sslSetup();
 		}
 
-        installHubOnce();
+        clearDatabases();
+        createProjectDir();
+
         enableTracing();
         enableDebugging();
 
         scaffolding = Scaffolding.create(projectDir.toString(), finalClient);
         scaffolding.createEntity(ENTITY);
+
 
         scaffoldFlows("scaffolded");
 
@@ -891,10 +895,7 @@ public class EndToEndFlowTests extends HubTestBase {
     }
 
     private void installDocs(DataFormat dataFormat, String collection, DatabaseClient srcClient, boolean useEs) {
-        DataMovementManager mgr = stagingDataMovementManager;
-        if (srcClient.getDatabase().equals(HubConfig.DEFAULT_FINAL_NAME)) {
-            mgr = finalDataMovementManager;
-        }
+        DataMovementManager mgr = srcClient.newDataMovementManager();
 
         WriteBatcher writeBatcher = mgr.newWriteBatcher()
             .withBatchSize(100)
@@ -936,7 +937,7 @@ public class EndToEndFlowTests extends HubTestBase {
         }
     }
 
-    private void testInputFlowViaMlcp(String prefix, String fileSuffix, DatabaseClient databaseClient, CodeFormat codeFormat, DataFormat dataFormat, boolean useEs, Map<String, Object> options, FinalCounts finalCounts) {
+    private void testInputFlowViaMlcp(String prefix, String fileSuffix, DatabaseClient databaseClient, CodeFormat codeFormat, DataFormat dataFormat, boolean useEs, Map<String, Object> options, FinalCounts finalCounts) throws InterruptedException {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_TRACE_NAME, HubConfig.DEFAULT_JOB_NAME);
 
         String flowName = getFlowName(prefix, codeFormat, dataFormat, FlowType.INPUT, useEs);
@@ -994,6 +995,8 @@ public class EndToEndFlowTests extends HubTestBase {
         }
         logger.error(mlcpRunner.getProcessOutput());
 
+        // wait for completion
+        Thread.sleep(2000);
         int stagingCount = getStagingDocCount();
         int finalCount = getFinalDocCount();
         int tracingCount = getTracingDocCount();
@@ -1001,6 +1004,7 @@ public class EndToEndFlowTests extends HubTestBase {
 
         assertEquals(finalCounts.stagingCount, stagingCount);
         assertEquals(finalCounts.finalCount, finalCount);
+        // most currently failing tests are cause of trace.
         assertEquals(finalCounts.tracingCount, tracingCount);
         assertEquals(finalCounts.jobCount, jobsCount);
 
@@ -1270,8 +1274,8 @@ public class EndToEndFlowTests extends HubTestBase {
     private void testHarmonizeFlow(
         String prefix, CodeFormat codeFormat, DataFormat dataFormat, boolean useEs,
         Map<String, Object> options, DatabaseClient srcClient, String destDb,
-        FinalCounts finalCounts, boolean waitForCompletion)
-    {
+        FinalCounts finalCounts, boolean waitForCompletion) throws InterruptedException {
+        clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_TRACE_NAME, HubConfig.DEFAULT_JOB_NAME);
         String flowName = getFlowName(prefix, codeFormat, dataFormat, FlowType.HARMONIZE, useEs);
 
         Vector<String> completed = new Vector<>();
@@ -1280,6 +1284,8 @@ public class EndToEndFlowTests extends HubTestBase {
         Tuple<FlowRunner, JobTicket> tuple = runHarmonizeFlow(flowName, dataFormat, completed, failed, options, srcClient, destDb, useEs, waitForCompletion);
 
         if (waitForCompletion) {
+            // takes a little time to run.
+            Thread.sleep(2000);
             int stagingCount = getStagingDocCount();
             int finalCount = getFinalDocCount();
             int tracingCount = getTracingDocCount();

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/jupiterbased/ScaffoldingE2E.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/jupiterbased/ScaffoldingE2E.java
@@ -55,7 +55,7 @@ public class ScaffoldingE2E extends HubTestBase {
         XMLUnit.setIgnoreWhitespace(true);
         deleteProjectDir();
 
-        installHubOnce();
+        createProjectDir();
     }
 
     private void createFlow(CodeFormat codeFormat, DataFormat dataFormat, FlowType flowType, boolean useEsModel) {

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/scaffolding/ScaffoldingTest.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/scaffolding/ScaffoldingTest.java
@@ -55,7 +55,7 @@ public class ScaffoldingTest extends HubTestBase {
         XMLUnit.setIgnoreWhitespace(true);
         deleteProjectDir();
 
-        installHubOnce();
+        createProjectDir();
         isMl9 = getMlMajorVersion() == 9;
     }
 

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/util/ComboListener.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/util/ComboListener.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.marklogic.hub.jupiterbased;
+package com.marklogic.hub.util;
 
 import com.marklogic.hub.flow.CodeFormat;
 import com.marklogic.hub.flow.DataFormat;

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/util/Installer.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/util/Installer.java
@@ -1,0 +1,34 @@
+package com.marklogic.hub.util;
+
+import com.marklogic.hub.HubTestBase;
+import org.junit.Test;
+
+public class Installer {
+
+
+    HubTestBase htb;
+
+    public void installHubOnce() {
+        htb.createProjectDir();
+        htb.getDataHub().install();
+    }
+
+    public void uninstallHub() {
+        htb.createProjectDir();
+        htb.getDataHub().uninstall();
+        htb.deleteProjectDir();
+
+    }
+    public Installer() {
+        htb = new HubTestBase();
+        if(htb.isSslRun() || htb.isCertAuth()) {
+            htb.sslCleanup();
+        }
+    }
+
+    public void main() {
+        Installer installer = new Installer();
+        installer.installHubOnce();
+        //installer.uninstallHub();
+    }
+}

--- a/marklogic-data-hub/src/test/java/com/marklogic/hub/util/Installer.java
+++ b/marklogic-data-hub/src/test/java/com/marklogic/hub/util/Installer.java
@@ -8,27 +8,28 @@ public class Installer {
 
     HubTestBase htb;
 
+    public Installer() {
+        htb = new HubTestBase();
+    }
+
+    // A method to manually setup
+    // uncomment @Test and run
+    // do NOT check in as a a test.
+    // @Test
     public void installHubOnce() {
         htb.createProjectDir();
         htb.getDataHub().install();
     }
 
+    // A method to manually teardown.
+    // uncomment @Test and run
+    // do NOT check in as a a test.
+    //@Test
     public void uninstallHub() {
         htb.createProjectDir();
         htb.getDataHub().uninstall();
         htb.deleteProjectDir();
 
     }
-    public Installer() {
-        htb = new HubTestBase();
-        if(htb.isSslRun() || htb.isCertAuth()) {
-            htb.sslCleanup();
-        }
-    }
 
-    public void main() {
-        Installer installer = new Installer();
-        installer.installHubOnce();
-        //installer.uninstallHub();
-    }
 }

--- a/quick-start/build.gradle
+++ b/quick-start/build.gradle
@@ -213,3 +213,7 @@ springBoot {
     mainClass = "com.marklogic.quickstart.Application"
     buildInfo()
 }
+
+test {
+  include 'com/marklogic/quickstart/WebTestSuite.class'
+}

--- a/quick-start/build.gradle
+++ b/quick-start/build.gradle
@@ -168,7 +168,7 @@ task startRest {
 
 task e2eLaunch(type: NpmTask) {
     args = ['run', 'e2e']
-    dependsOn buildUI, startRest
+    dependsOn compileJava, buildUI, startRest
 }
 
 task e2eUI {

--- a/quick-start/src/main/java/com/marklogic/quickstart/EnvironmentAware.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/EnvironmentAware.java
@@ -28,7 +28,7 @@ public class EnvironmentAware {
 
     protected final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    protected EnvironmentConfig envConfig() {
+    public EnvironmentConfig envConfig() {
         ConnectionAuthenticationToken authenticationToken = (ConnectionAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
         if (authenticationToken != null) {
             _envConfig = authenticationToken.getEnvironmentConfig();

--- a/quick-start/src/main/java/com/marklogic/quickstart/service/EntityManagerService.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/service/EntityManagerService.java
@@ -67,15 +67,10 @@ public class EntityManagerService {
     @Autowired
     private DataHubService dataHubService;
 
-    private EnvironmentConfig envConfig() {
-        ConnectionAuthenticationToken authenticationToken = (ConnectionAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
-        return authenticationToken.getEnvironmentConfig();
-    }
-
     public List<EntityModel> getLegacyEntities() throws IOException {
-        String projectDir = envConfig().getProjectDir();
+        String projectDir = ServiceConfiguration.envConfig().getProjectDir();
         List<EntityModel> entities = new ArrayList<>();
-        Path entitiesDir = envConfig().getMlSettings().getHubEntitiesDir();
+        Path entitiesDir = ServiceConfiguration.envConfig().getMlSettings().getHubEntitiesDir();
         List<String> entityNames = FileUtil.listDirectFolders(entitiesDir.toFile());
         for (String entityName : entityNames) {
             EntityModel entityModel = new EntityModel();
@@ -90,15 +85,15 @@ public class EntityManagerService {
     }
 
     public List<EntityModel> getEntities() throws IOException {
-        if (envConfig().getMarklogicVersion().startsWith("8")) {
+        if (ServiceConfiguration.envConfig().getMarklogicVersion().startsWith("8")) {
             return getLegacyEntities();
         }
 
-        String projectDir = envConfig().getProjectDir();
+        String projectDir = ServiceConfiguration.envConfig().getProjectDir();
 
         Map<String, HubUIData> hubUiData = getUiData();
         List<EntityModel> entities = new ArrayList<>();
-        Path entitiesPath = Paths.get(envConfig().getProjectDir(), PLUGINS_DIR, ENTITIES_DIR);
+        Path entitiesPath = Paths.get(ServiceConfiguration.envConfig().getProjectDir(), PLUGINS_DIR, ENTITIES_DIR);
         List<String> entityNames = FileUtil.listDirectFolders(entitiesPath.toFile());
         ObjectMapper objectMapper = new ObjectMapper();
         for (String entityName : entityNames) {
@@ -126,7 +121,7 @@ public class EntityManagerService {
     }
 
     public EntityModel createEntity(String projectDir, EntityModel newEntity) throws IOException {
-        Scaffolding scaffolding = Scaffolding.create(projectDir, envConfig().getFinalClient());
+        Scaffolding scaffolding = Scaffolding.create(projectDir, ServiceConfiguration.envConfig().getFinalClient());
         scaffolding.createEntity(newEntity.getName());
 
         if (newEntity.inputFlows != null) {
@@ -151,7 +146,7 @@ public class EntityManagerService {
         String title = entity.getInfo().getTitle();
 
         if (fullpath == null) {
-            Path dir = Paths.get(envConfig().getProjectDir(), PLUGINS_DIR, ENTITIES_DIR, title);
+            Path dir = Paths.get(ServiceConfiguration.envConfig().getProjectDir(), PLUGINS_DIR, ENTITIES_DIR, title);
             if (!dir.toFile().exists()) {
                 dir.toFile().mkdirs();
             }
@@ -184,7 +179,7 @@ public class EntityManagerService {
                 entity.setFilename(fullpath);
 
                 // Redeploy the flows
-                dataHubService.reinstallUserModules(envConfig().getMlSettings(), null, null);
+                dataHubService.reinstallUserModules(ServiceConfiguration.envConfig().getMlSettings(), null, null);
             }
         }
 
@@ -196,7 +191,7 @@ public class EntityManagerService {
     }
 
     public void deleteEntity(String entity) throws IOException {
-        Path dir = Paths.get(envConfig().getProjectDir(), PLUGINS_DIR, ENTITIES_DIR, entity);
+        Path dir = Paths.get(ServiceConfiguration.envConfig().getProjectDir(), PLUGINS_DIR, ENTITIES_DIR, entity);
         if (dir.toFile().exists()) {
             watcherService.unwatch(dir.getParent().toString());
             FileUtils.deleteDirectory(dir.toFile());
@@ -223,7 +218,7 @@ public class EntityManagerService {
             uiData = JsonNodeFactory.instance.objectNode();
         }
 
-        Path dir = Paths.get(envConfig().getProjectDir(), HubConfig.USER_CONFIG_DIR);
+        Path dir = Paths.get(ServiceConfiguration.envConfig().getProjectDir(), HubConfig.USER_CONFIG_DIR);
         if (!dir.toFile().exists()) {
             dir.toFile().mkdirs();
         }
@@ -253,7 +248,7 @@ public class EntityManagerService {
             uiData = JsonNodeFactory.instance.objectNode();
         }
 
-        Path dir = Paths.get(envConfig().getProjectDir(), HubConfig.USER_CONFIG_DIR);
+        Path dir = Paths.get(ServiceConfiguration.envConfig().getProjectDir(), HubConfig.USER_CONFIG_DIR);
         if (!dir.toFile().exists()) {
             dir.toFile().mkdirs();
         }
@@ -301,14 +296,14 @@ public class EntityManagerService {
     }
 
     public FlowModel createFlow(String projectDir, String entityName, FlowType flowType, FlowModel newFlow) throws IOException {
-        Scaffolding scaffolding = Scaffolding.create(projectDir, envConfig().getFinalClient());
+        Scaffolding scaffolding = Scaffolding.create(projectDir, ServiceConfiguration.envConfig().getFinalClient());
         newFlow.entityName = entityName;
         scaffolding.createFlow(entityName, newFlow.flowName, flowType, newFlow.codeFormat, newFlow.dataFormat, newFlow.useEsModel);
         return getFlow(entityName, flowType, newFlow.flowName);
     }
 
     public void deleteFlow(String projectDir, String entityName, String flowName, FlowType flowType) throws IOException {
-        Scaffolding scaffolding = Scaffolding.create(projectDir, envConfig().getFinalClient());
+        Scaffolding scaffolding = Scaffolding.create(projectDir, ServiceConfiguration.envConfig().getFinalClient());
         Path flowDir = scaffolding.getFlowDir(entityName, flowName, flowType);
         FileUtils.deleteDirectory(flowDir.toFile());
     }
@@ -340,7 +335,7 @@ public class EntityManagerService {
     }
     private JsonNode getUiRawData() {
         JsonNode json = null;
-        Path dir = Paths.get(envConfig().getProjectDir(), HubConfig.USER_CONFIG_DIR);
+        Path dir = Paths.get(ServiceConfiguration.envConfig().getProjectDir(), HubConfig.USER_CONFIG_DIR);
         File file = Paths.get(dir.toString(), UI_LAYOUT_FILE).toFile();
         if (file.exists()) {
             try {

--- a/quick-start/src/main/java/com/marklogic/quickstart/service/ServiceConfiguration.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/service/ServiceConfiguration.java
@@ -1,0 +1,27 @@
+package com.marklogic.quickstart.service;
+
+import com.marklogic.hub.EntityManager;
+import com.marklogic.hub.FlowManager;
+import com.marklogic.hub.entity.Entity;
+import com.marklogic.quickstart.auth.ConnectionAuthenticationToken;
+import com.marklogic.quickstart.model.EnvironmentConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class ServiceConfiguration {
+
+    public static EnvironmentConfig envConfig() {
+        SecurityContext context = SecurityContextHolder.getContext();
+        ConnectionAuthenticationToken authenticationToken = (ConnectionAuthenticationToken) context.getAuthentication();
+        return authenticationToken.getEnvironmentConfig();
+    }
+
+    @Bean
+    public FlowManager flowManager() {
+        return FlowManager.create(envConfig().getMlSettings());
+    };
+
+}

--- a/quick-start/src/main/java/com/marklogic/quickstart/service/ServiceConfiguration.java
+++ b/quick-start/src/main/java/com/marklogic/quickstart/service/ServiceConfiguration.java
@@ -2,26 +2,36 @@ package com.marklogic.quickstart.service;
 
 import com.marklogic.hub.EntityManager;
 import com.marklogic.hub.FlowManager;
+import com.marklogic.hub.HubConfigBuilder;
 import com.marklogic.hub.entity.Entity;
+import com.marklogic.quickstart.EnvironmentAware;
 import com.marklogic.quickstart.auth.ConnectionAuthenticationToken;
 import com.marklogic.quickstart.model.EnvironmentConfig;
+import org.apache.commons.io.FileUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Scope;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-@Configuration
-public class ServiceConfiguration {
+import javax.annotation.PostConstruct;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
-    public static EnvironmentConfig envConfig() {
-        SecurityContext context = SecurityContextHolder.getContext();
-        ConnectionAuthenticationToken authenticationToken = (ConnectionAuthenticationToken) context.getAuthentication();
-        return authenticationToken.getEnvironmentConfig();
-    }
+@Configuration
+public class ServiceConfiguration extends EnvironmentAware {
 
     @Bean
+    @Scope("prototype")
     public FlowManager flowManager() {
-        return FlowManager.create(envConfig().getMlSettings());
+        if (envConfig() == null) {
+            return null;
+        } else {
+            return FlowManager.create(envConfig().getMlSettings());
+        }
     };
 
 }

--- a/quick-start/src/test/java/com/marklogic/quickstart/WebTestSuite.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/WebTestSuite.java
@@ -1,0 +1,41 @@
+package com.marklogic.quickstart;
+
+
+import com.marklogic.hub.util.Installer;
+import com.marklogic.quickstart.service.EntityManagerServiceTest;
+import com.marklogic.quickstart.service.FlowManagerServiceTest;
+import com.marklogic.quickstart.service.JobServiceTest;
+import com.marklogic.quickstart.service.TraceServiceTest;
+import com.marklogic.quickstart.web.EntitiesControllerTest;
+import com.marklogic.quickstart.web.HubConfigJsonTest;
+import com.marklogic.quickstart.web.ProjectsControllerTest;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses( {
+    EntityManagerServiceTest.class,
+    FlowManagerServiceTest.class,
+    JobServiceTest.class,
+    TraceServiceTest.class,
+    EntitiesControllerTest.class,
+    HubConfigJsonTest.class,
+    ProjectsControllerTest.class
+})
+
+public class WebTestSuite {
+
+    @BeforeClass
+    public static void setUp() {
+        new Installer().installHubOnce();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        new Installer().uninstallHub();
+    }
+
+}

--- a/quick-start/src/test/java/com/marklogic/quickstart/service/AbstractServiceTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/service/AbstractServiceTest.java
@@ -19,7 +19,6 @@ public class AbstractServiceTest extends HubTestBase {
         createProjectDir();
         EnvironmentConfig envConfig = new EnvironmentConfig(PROJECT_PATH, null, "admin", "admin");
         envConfig.setMlSettings(HubConfigBuilder.newHubConfigBuilder(PROJECT_PATH).withPropertiesFromEnvironment().build());
-        // this method throws an exception on initialization so ridding of it.
         envConfig.checkIfInstalled();
         setEnvConfig(envConfig);
     }

--- a/quick-start/src/test/java/com/marklogic/quickstart/service/AbstractServiceTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/service/AbstractServiceTest.java
@@ -4,14 +4,22 @@ import com.marklogic.hub.HubConfigBuilder;
 import com.marklogic.hub.HubTestBase;
 import com.marklogic.quickstart.auth.ConnectionAuthenticationToken;
 import com.marklogic.quickstart.model.EnvironmentConfig;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import javax.annotation.PostConstruct;
+import javax.ws.rs.POST;
+
+@Configuration
 public class AbstractServiceTest extends HubTestBase {
 
 
+    @PostConstruct
     protected void setupEnv() {
+        createProjectDir();
         EnvironmentConfig envConfig = new EnvironmentConfig(PROJECT_PATH, null, "admin", "admin");
         envConfig.setMlSettings(HubConfigBuilder.newHubConfigBuilder(PROJECT_PATH).withPropertiesFromEnvironment().build());
+        // this method throws an exception on initialization so ridding of it.
         envConfig.checkIfInstalled();
         setEnvConfig(envConfig);
     }

--- a/quick-start/src/test/java/com/marklogic/quickstart/service/EntityManagerServiceTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/service/EntityManagerServiceTest.java
@@ -54,8 +54,7 @@ public class EntityManagerServiceTest extends AbstractServiceTest {
 
     @Before
     public void setUp() {
-        installHubOnce();
-        setupEnv();
+        createProjectDir();
 
         Scaffolding scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
         scaffolding.createEntity(ENTITY);

--- a/quick-start/src/test/java/com/marklogic/quickstart/service/FlowManagerServiceTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/service/FlowManagerServiceTest.java
@@ -60,8 +60,7 @@ public class FlowManagerServiceTest extends AbstractServiceTest {
     private static String ENTITY = "test-entity";
     private static Path projectDir = Paths.get(".", PROJECT_PATH);
 
-    @Autowired private ApplicationContext context;
-
+    @Autowired
     FlowManagerService fm;
 
     @Before
@@ -109,7 +108,6 @@ public class FlowManagerServiceTest extends AbstractServiceTest {
         FileUtil.copy(getResourceStream("flow-manager/sjs-harmonize-flow/headers.sjs"), harmonizeDir.resolve("sjs-json-harmonization-flow/headers.sjs").toFile());
 
         installUserModules(getHubConfig(), true);
-        fm = context.getBean(FlowManagerService.class);
     }
 
     protected void setEnvConfig(EnvironmentConfig envConfig) {

--- a/quick-start/src/test/java/com/marklogic/quickstart/service/FlowManagerServiceTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/service/FlowManagerServiceTest.java
@@ -41,9 +41,12 @@ import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -57,17 +60,13 @@ public class FlowManagerServiceTest extends AbstractServiceTest {
     private static String ENTITY = "test-entity";
     private static Path projectDir = Paths.get(".", PROJECT_PATH);
 
-    @Autowired
+    @Autowired private ApplicationContext context;
+
     FlowManagerService fm;
 
     @Before
     public void setup() {
-        deleteProjectDir();
-
-
-        installHubOnce();
-
-        setupEnv();
+        createProjectDir();
 
         Scaffolding scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
         scaffolding.createEntity(ENTITY);
@@ -110,6 +109,7 @@ public class FlowManagerServiceTest extends AbstractServiceTest {
         FileUtil.copy(getResourceStream("flow-manager/sjs-harmonize-flow/headers.sjs"), harmonizeDir.resolve("sjs-json-harmonization-flow/headers.sjs").toFile());
 
         installUserModules(getHubConfig(), true);
+        fm = context.getBean(FlowManagerService.class);
     }
 
     protected void setEnvConfig(EnvironmentConfig envConfig) {
@@ -161,7 +161,7 @@ public class FlowManagerServiceTest extends AbstractServiceTest {
                 "\"output_permissions\":\"\\\"rest-reader,read,rest-writer,update\\\"\"," +
                 "\"output_uri_replace\":\"\\\"" + basePath.replace("\\", "/").replaceAll("^([A-Za-z]):", "/$1:") + ",''\\\"\"," +
                 "\"document_type\":\"\\\"json\\\"\"," +
-                "\"transform_module\":\"\\\"/MarkLogic/data-hub-framework/transforms/mlcp-flow-transform.xqy\\\"\"," +
+                "\"transform_module\":\"\\\"/MarkLogic/data-hub-framework/transforms/mlcp-flow-transform.sjs\\\"\"," +
                 "\"transform_namespace\":\"\\\"http://marklogic.com/data-hub/mlcp-flow-transform\\\"\"," +
                 "\"transform_param\":\"\\\"entity-name=" + ENTITY + ",flow-name=" + flowName + "\\\"\"" +
                 "}");

--- a/quick-start/src/test/java/com/marklogic/quickstart/service/JobServiceTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/service/JobServiceTest.java
@@ -30,7 +30,7 @@ public class JobServiceTest extends HubTestBase {
     @Before
     public void setup() throws IOException {
         deleteProjectDir();
-        installHubOnce();
+        createProjectDir();
     }
 
     @Test

--- a/quick-start/src/test/java/com/marklogic/quickstart/service/TraceServiceTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/service/TraceServiceTest.java
@@ -29,8 +29,10 @@ import com.marklogic.hub.scaffold.Scaffolding;
 import com.marklogic.quickstart.auth.ConnectionAuthenticationToken;
 import com.marklogic.quickstart.model.EnvironmentConfig;
 import com.marklogic.quickstart.model.TraceQuery;
+import net.sf.saxon.functions.Abs;
 import org.junit.*;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -42,12 +44,13 @@ import java.util.HashMap;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest()
-public class TraceServiceTest extends HubTestBase {
+public class TraceServiceTest extends AbstractServiceTest {
 
     private DatabaseClient traceClient;
     private static Path projectDir = Paths.get(".", PROJECT_PATH);
     private static String ENTITY = "test-entity";
 
+    @Autowired
     private FlowManagerService flowMgrService;
 
 
@@ -58,7 +61,7 @@ public class TraceServiceTest extends HubTestBase {
         envConfig.setMlSettings(HubConfigBuilder.newHubConfigBuilder(".").withPropertiesFromEnvironment().build());
         envConfig.checkIfInstalled();
         setEnvConfig(envConfig);
-        installHubOnce();
+        createProjectDir();
         enableTracing();
 
         Scaffolding scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
@@ -73,7 +76,6 @@ public class TraceServiceTest extends HubTestBase {
         clearDatabases(HubConfig.DEFAULT_STAGING_NAME, HubConfig.DEFAULT_FINAL_NAME, HubConfig.DEFAULT_TRACE_NAME, HubConfig.DEFAULT_JOB_NAME);
 
         traceClient = getHubConfig().newTraceDbClient();
-        flowMgrService =  new FlowManagerService();
         final String FLOW_NAME = "sjs-json-harmonize-flow";
         Flow flow = flowMgrService.getServerFlow(ENTITY, FLOW_NAME, FlowType.HARMONIZE);
         flowMgrService.runFlow(flow, 1, 1, new HashMap<String, Object>(), (jobId, percentComplete, message) -> { });

--- a/quick-start/src/test/java/com/marklogic/quickstart/web/BaseTestController.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/web/BaseTestController.java
@@ -42,14 +42,14 @@ public class BaseTestController extends HubTestBase {
 
     protected void setEnvConfig(EnvironmentConfig envConfig) {
 
-        ConnectionAuthenticationToken authenticationToken = new ConnectionAuthenticationToken("admin", "admin", "localhost", 1, "local");
+        ConnectionAuthenticationToken authenticationToken = new ConnectionAuthenticationToken("admin", "admin", envConfig.getMlSettings().getHost(), 1, "local");
         authenticationToken.setEnvironmentConfig(envConfig);
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
     }
 
     @Before
     public void baseSetUp() throws IOException {
-        envConfig = new EnvironmentConfig(PROJECT_PATH, "local", "admin", "admin");
+        envConfig = new EnvironmentConfig(PROJECT_PATH, null, "admin", "admin");
         setEnvConfig(envConfig);
         DataHub dh = DataHub.create(envConfig.getMlSettings());
         dh.initProject();
@@ -58,6 +58,6 @@ public class BaseTestController extends HubTestBase {
 
     @After
     public void baseTeardown() throws IOException {
-        FileUtils.deleteDirectory(new File(PROJECT_PATH));
+        deleteProjectDir();
     }
 }

--- a/quick-start/src/test/java/com/marklogic/quickstart/web/EntitiesControllerTest.java
+++ b/quick-start/src/test/java/com/marklogic/quickstart/web/EntitiesControllerTest.java
@@ -55,6 +55,7 @@ public class EntitiesControllerTest extends BaseTestController {
     @Autowired
     private EntitiesController ec;
 
+
     @Test
     public void getInputFlowOptions() throws Exception {
         String path = "/some/project/path";
@@ -78,9 +79,12 @@ public class EntitiesControllerTest extends BaseTestController {
 
     @Test
     public void runHarmonizeNoOptions() throws IOException, InterruptedException {
-        // Set up (not needed for other tests)
-        baseSetUp();
-        installHubOnce();
+        deleteProjectDir();
+        createProjectDir();
+
+        envConfig.setInitialized(true);
+        envConfig.setProjectDir(PROJECT_PATH);
+        envConfig.setMlSettings(HubConfigBuilder.newHubConfigBuilder(PROJECT_PATH).withPropertiesFromEnvironment().build());
 
         Path projectDir = Paths.get(".", PROJECT_PATH);
         Scaffolding scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
@@ -107,22 +111,24 @@ public class EntitiesControllerTest extends BaseTestController {
         ResponseEntity<?> responseEntity = ec.runHarmonizeFlow(ENTITY, "sjs-json-harmonization-flow", body);
 
         Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        // document takes a moment to arrive.
+        Thread.sleep(1000);
         DocumentRecord doc = finalDocMgr.read("/staged.json").next();
         JsonNode root = doc.getContent(new JacksonHandle()).get();
         JsonNode env = root.path("envelope");
         JsonNode headers = env.path("headers");
         JsonNode optionNode = headers.path("test-option");
         Assert.assertTrue(optionNode.isMissingNode());
-
-        uninstallHub();
     }
 
     @Test
     public void runHarmonizeFlowWithOptions() throws IOException, InterruptedException {
-        // Set up (not needed for other tests)
-        baseSetUp();
-        installHubOnce();
+        deleteProjectDir();
+        createProjectDir();
 
+        envConfig.setInitialized(true);
+        envConfig.setProjectDir(PROJECT_PATH);
+        envConfig.setMlSettings(HubConfigBuilder.newHubConfigBuilder(PROJECT_PATH).withPropertiesFromEnvironment().build());
         Path projectDir = Paths.get(".", PROJECT_PATH);
         Scaffolding scaffolding = Scaffolding.create(projectDir.toString(), stagingClient);
 
@@ -149,6 +155,8 @@ public class EntitiesControllerTest extends BaseTestController {
         ResponseEntity<?> responseEntity = ec.runHarmonizeFlow(ENTITY, "sjs-json-harmonization-flow", body);
 
         Assert.assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+        // document takes a moment to arrive.
+        Thread.sleep(1000);
         DocumentRecord doc = finalDocMgr.read("/staged.json").next();
         JsonNode root = doc.getContent(new JacksonHandle()).get();
         JsonNode env = root.path("envelope");
@@ -157,7 +165,7 @@ public class EntitiesControllerTest extends BaseTestController {
         Assert.assertFalse(optionNode.isMissingNode());
         Assert.assertEquals(OPT_VALUE, optionNode.asText());
 
-        uninstallHub();
+        //uninstallHub();
     }
 
 }


### PR DESCRIPTION
This PR, again, delivers some big changes to unit tests.
It has a small issue, again something with setup and teardown, where tracing counts fail for certain legacy flows.

When I run the tests with develop, then run the e2e tests on this branch, they all pass. mysterious what prevents tracing from working on these handful of tests.

also there's a init() test which fails once during a whole run, then passes.  This looks like an innocuous issue.

I'd like a good analysis from @srinath as first priority, as getting this right is blocking my other fixes for the sprint.