### PR TITLE
DHFPROD-496 fix QuickStart naming in app

### DIFF
--- a/quick-start/src/main/ui/app/header/header.component.html
+++ b/quick-start/src/main/ui/app/header/header.component.html
@@ -1,7 +1,7 @@
 <header class="mdl-layout__header">
   <div class="mdl-layout__header-row">
     <img src="assets/img/odh.svg">
-    <span class="mdl-layout-title">Data Hub Quick Start</span>
+    <span class="mdl-layout-title">Data Hub QuickStart</span>
     <!-- Add spacer, to align navigation to the right -->
     <div class="mdl-layout-spacer"></div>
     <div *ngIf="getRunningJobCount() !== 0" layout="row" layout-align="center center" class="job-progress" (click)="gotoJobs()">

--- a/quick-start/src/main/ui/app/login/login.component.html
+++ b/quick-start/src/main/ui/app/login/login.component.html
@@ -4,7 +4,7 @@
   </div>
   <div class="login-wrapper" layout="row" layout-align="center start">
     <section layout="column" layout-align="center center" class="left-pane">
-      <h1 id="mla-loginPage-Text">Data Hub Quick Start</h1>
+      <h1 id="mla-loginPage-Text">Data Hub QuickStart</h1>
       <img class="odh-icon" src="assets/img/odh.svg">
       <section flex layout-padding class="install-status" *ngIf="installationStatus">
         <pre>{{installationStatus}}</pre>
@@ -165,7 +165,7 @@
 
             <p class="help-text">Each Hub Project can be deployed to multiple environments. Environments are
             determined by the presence of a gradle-env.properties file in your hub project
-            directory. By default the Quick Start only creates a local environment file.
+            directory. By default QuickStart only creates a local environment file.
             Read more <a target="_blank" href="https://github.com/marklogic-community/marklogic-data-hub/wiki/Data-Hub-QuickStart-Project-Environments">on the Data Hub Framework Wiki</a>.
             </p>
             <app-select-list

--- a/quick-start/src/main/ui/index.html
+++ b/quick-start/src/main/ui/index.html
@@ -42,7 +42,7 @@
       font-size: 60px;
     }
     </style>
-    Quick Start Loading...
+    QuickStart Loading...
   </app-root>
   <dialog-outlet></dialog-outlet>
 


### PR DESCRIPTION
“QuickStart”, not “Quick Start”